### PR TITLE
Fix/logo accessibility

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -316,8 +316,8 @@ if ( ! function_exists( 'twentytwenty_get_custom_logo' ) ) :
 
 		?>
 
-		<a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php bloginfo( 'name' ); ?>" class="custom-logo-link <?php echo esc_attr( $logo_theme_mod_class ); ?>">
-			<img src="<?php echo esc_url( $logo_url ); ?>" width="<?php echo esc_attr( $logo_width ); ?>" height="<?php echo esc_attr( $logo_height ); ?>" />
+		<a href="<?php echo esc_url( home_url( '/' ) ); ?>" class="custom-logo-link <?php echo esc_attr( $logo_theme_mod_class ); ?>">
+			<img src="<?php echo esc_url( $logo_url ); ?>" width="<?php echo esc_attr( $logo_width ); ?>" height="<?php echo esc_attr( $logo_height ); ?>" alt="<?php bloginfo( 'name' ); ?>" />
 		</a>
 
 		<?php

--- a/functions.php
+++ b/functions.php
@@ -89,8 +89,8 @@ if ( ! function_exists( 'twentytwenty_theme_support' ) ) :
 		/*
 		 * Make theme available for translation.
 		 * Translations can be filed in the /languages/ directory.
-		 * If you're building a theme based on Twenty Twenty, use a find and replace
-		 * to change 'twentytwenty' to the name of your theme in all the template files.
+		 * If you're building a theme based on Twenty Nineteen, use a find and replace
+		 * to change 'twentynineteen' to the name of your theme in all the template files.
 		 */
 		load_theme_textdomain( 'twentytwenty', get_template_directory() . '/languages' );
 

--- a/functions.php
+++ b/functions.php
@@ -89,8 +89,8 @@ if ( ! function_exists( 'twentytwenty_theme_support' ) ) :
 		/*
 		 * Make theme available for translation.
 		 * Translations can be filed in the /languages/ directory.
-		 * If you're building a theme based on Twenty Nineteen, use a find and replace
-		 * to change 'twentynineteen' to the name of your theme in all the template files.
+		 * If you're building a theme based on Twenty Twenty, use a find and replace
+		 * to change 'twentytwenty' to the name of your theme in all the template files.
 		 */
 		load_theme_textdomain( 'twentytwenty', get_template_directory() . '/languages' );
 

--- a/header.php
+++ b/header.php
@@ -15,13 +15,13 @@
 
 	<body <?php body_class(); ?>>
 
-		<a class="skip-link faux-button" href="#site-content"><?php _e( 'Skip to the content', 'twentytwenty' ); ?></a>
-
-		<?php 
+		<?php
 		if ( function_exists( 'wp_body_open' ) ) {
-			wp_body_open(); 
+			wp_body_open();
 		}
 		?>
+
+		<a class="skip-link faux-button" href="#site-content"><?php _e( 'Skip to the content', 'twentytwenty' ); ?></a>
 
 		<header id="site-header">
 

--- a/header.php
+++ b/header.php
@@ -15,13 +15,13 @@
 
 	<body <?php body_class(); ?>>
 
-		<?php
+		<a class="skip-link faux-button" href="#site-content"><?php _e( 'Skip to the content', 'twentytwenty' ); ?></a>
+
+		<?php 
 		if ( function_exists( 'wp_body_open' ) ) {
-			wp_body_open();
+			wp_body_open(); 
 		}
 		?>
-
-		<a class="skip-link faux-button" href="#site-content"><?php _e( 'Skip to the content', 'twentytwenty' ); ?></a>
 
 		<header id="site-header">
 


### PR DESCRIPTION
In function `twentytwenty_get_custom_logo()` located in `functions.php`, there is two accessibility issues:
- `title` attribute should be removed from the link
- an `alt` attribute should be added in the image tag

I'd propose to use the blog title as an `alt` attribute since this is the logo of the website.

Fixes #21 