### PR TITLE
Use `wp_body_open` for output of skip link

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -328,6 +328,14 @@ if ( ! function_exists( 'twentytwenty_get_custom_logo' ) ) :
 	}
 endif;
 
+/**
+ * Shim for wp_body_open, ensuring backwards compatibility with versions of WordPress older than 5.2.
+ */
+if ( ! function_exists( 'wp_body_open' ) ) {
+	function wp_body_open() {
+		do_action( 'wp_body_open' );
+	}
+}
 
 /**
  * Include a skip to content link at the top of the page so that users can bypass the menu.

--- a/functions.php
+++ b/functions.php
@@ -328,6 +328,18 @@ if ( ! function_exists( 'twentytwenty_get_custom_logo' ) ) :
 	}
 endif;
 
+
+/**
+ * Include a skip to content link at the top of the page so that users can bypass the menu.
+ */
+if ( ! function_exists( 'twentytwenty_skip_link' ) ) :
+	function twentytwenty_skip_link() {
+		echo '<a class="skip-link faux-button" href="#site-content">' . esc_html__( 'Skip to the content', 'twentytwenty' ) . '</a>';
+	}
+	add_action( 'wp_body_open', 'twentytwenty_skip_link', 5 );
+endif;
+
+
 /**
  * Register widget areas.
  *

--- a/header.php
+++ b/header.php
@@ -15,8 +15,6 @@
 
 	<body <?php body_class(); ?>>
 
-		<a class="skip-link faux-button" href="#site-content"><?php _e( 'Skip to the content', 'twentytwenty' ); ?></a>
-
 		<?php 
 		if ( function_exists( 'wp_body_open' ) ) {
 			wp_body_open(); 

--- a/header.php
+++ b/header.php
@@ -16,9 +16,7 @@
 	<body <?php body_class(); ?>>
 
 		<?php 
-		if ( function_exists( 'wp_body_open' ) ) {
-			wp_body_open(); 
-		}
+		wp_body_open();
 		?>
 
 		<header id="site-header">


### PR DESCRIPTION
Moves the output of the skip link from `header.php` to the `wp_body_open` action, matching the approach that will be used [in Twenty Eleven](https://core.trac.wordpress.org/ticket/47891). This also makes sure that `wp_body_open()` is triggered right after the `<body>`.