### PR TITLE
modify top value to fix admin-bar overlap

### DIFF
--- a/style.css
+++ b/style.css
@@ -1196,6 +1196,16 @@ ul.social-icons li {
 		top: 0;
 }
 
+.admin-bar.overlay-header #site-header {
+	top: 32px;
+}
+
+@media (max-width: 782px) {
+	.admin-bar.overlay-header #site-header {
+		top: 46px;
+	}
+}
+
 .overlay-header:not(.showing-menu-modal):not(.overlay-header-has-text-color) .header-inner:not(.is-sticky) {
 	color: #fff;
 }


### PR DESCRIPTION
Modifies the top value of the `site-header` whenever the `admin-bar` is shown. Uses the height and the Media breakpoint core uses for the `admin-bar`

fix for #45 
