### PR TITLE
UPDATE #28: Add class .screen-reader-text to skip-link

### DIFF
--- a/header.php
+++ b/header.php
@@ -15,7 +15,7 @@
 
 	<body <?php body_class(); ?>>
 
-		<a class="skip-link faux-button" href="#site-content"><?php _e( 'Skip to the content', 'twentytwenty' ); ?></a>
+		<a class="skip-link screen-reader-text faux-button" href="#site-content"><?php _e( 'Skip to the content', 'twentytwenty' ); ?></a>
 
 		<?php 
 		if ( function_exists( 'wp_body_open' ) ) {


### PR DESCRIPTION
Fixes #28 

Before:

`<a class="skip-link faux-button" href="#site-content"><?php _e( 'Skip to the content', 'twentytwenty' ); ?></a>`

After:

`<a class="skip-link screen-reader-text faux-button" href="#site-content"><?php _e( 'Skip to the content', 'twentytwenty' ); ?></a>`