### PR TITLE
Remove post/page link when is_singular() is true

### DIFF
--- a/parts/page-header.php
+++ b/parts/page-header.php
@@ -5,7 +5,7 @@
 		<?php 
 
 		if ( is_singular() ) {
-			the_title( '<h1 class="entry-title"><a href="' . esc_url( get_permalink() ) . '">', '</a></h1>' );
+			the_title( '<h1 class="entry-title">', '</h1>' );
 		} else {
 			the_title( '<h2 class="entry-title heading-size-1"><a href="' . esc_url( get_permalink() ) . '">', '</a></h2>' );
 		}


### PR DESCRIPTION
Fixes #76

When on single page/post, it is not necessary to have a link to the same page.