### PR TITLE
Entry content fixes

### DIFF
--- a/style.css
+++ b/style.css
@@ -782,9 +782,11 @@ table {
 	border-collapse: collapse;
 	border-spacing: 0;
 	empty-cells: show;
+	font-size: 1.6rem;
 	margin: 4rem 0;
 	max-width: 100%;
 	overflow: hidden;
+	table-layout: fixed;
 	width: 100%;
 }
 
@@ -3016,6 +3018,10 @@ ul.footer-social li {
 		margin: 8rem 0;
 	}
 
+	table {
+		font-size: 1.8rem;
+	}
+
 	/* VANILLA GALLERIES */
 
 	.gallery-columns-2 .gallery-item { max-width: 50%; }
@@ -3343,10 +3349,6 @@ ul.footer-social li {
 	.entry-content p,
 	.entry-content li {
 		line-height: 1.476;
-	}
-
-	.entry-content table {
-		font-size: 1.8rem;
 	}
 
 	.entry-content h1,  

--- a/style.css
+++ b/style.css
@@ -104,6 +104,7 @@ body {
 	box-sizing: inherit;
 	-webkit-font-smoothing: antialiased;
 	word-break: break-word;
+  	word-wrap: break-word;
 }
 
 ::selection {

--- a/style.css
+++ b/style.css
@@ -685,7 +685,7 @@ textarea {
 
 select {
 	background-repeat: no-repeat;
-	background-image: url( 'data:image/svg+xml;utf8,<svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="12" viewBox="0 0 20 12"><polygon fill="#000000" fill-rule="evenodd" points="1319.899 365.778 1327.678 358 1329.799 360.121 1319.899 370.021 1310 360.121 1312.121 358" transform="translate(-1310 -358)" /></svg>');
+	background-image: url( 'data:image/svg+xml;utf8,<svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="12" viewBox="0 0 20 12"><polygon fill="color( display-p3 0.102 0.106 0.122 / 1 )" fill-rule="evenodd" points="1319.899 365.778 1327.678 358 1329.799 360.121 1319.899 370.021 1310 360.121 1312.121 358" transform="translate(-1310 -358)" /></svg>');
 	background-position: calc( 100% - 2rem ) center;
 	background-size: 1.4rem .9rem;
 	line-height: 1.3;


### PR DESCRIPTION
- Fix for select elements not showing the chevron in Firefox (fixes #86)
- Set tables to `table-layout: fixed`, and set the base table font size to 1.6rem (fixes #87)
- Amended `word-break: break-word` with `word-wrap: break-word`, for more extensive browser support (fixes #85)