### PR TITLE
Remove width: 100% from featured image element

### DIFF
--- a/style.css
+++ b/style.css
@@ -1951,14 +1951,25 @@ body.template-cover .entry-header {
 	position: relative;
 }
 
-.single .featured-media {
+.singular .featured-media {
 	margin-top: 0;
 }
 
-.single .featured-media-inner {
+.singular .featured-media-inner {
 	position: relative;
 		left: calc( 50% - 50vw );
 	width: 100vw;
+}
+
+.singular .featured-media:before {
+	background: #fff;
+	content: "";
+	display: block;
+	position: absolute;
+		bottom: 50%;
+		left: 0;
+		right: 0;
+		top: 0;
 }
 
 .featured-media img {
@@ -3725,18 +3736,6 @@ ul.footer-social li {
 	/* Template: [Template Name] ------------- */
 	/* Post: Archive ------------------------- */
 	/* Post: Single -------------------------- */
-
-	.single .featured-media:before {
-		background: #fff;
-		content: "";
-		display: block;
-		position: absolute;
-			bottom: 50%;
-			left: 0;
-			right: 0;
-			top: 0;
-	}
-
 	/* Blocks -------------------------------- */
 	/* Entry Content ------------------------- */
 

--- a/style.css
+++ b/style.css
@@ -1962,7 +1962,7 @@ body.template-cover .entry-header {
 }
 
 .featured-media img {
-	width: 100%;
+	margin: 0 auto;
 }
 
 .featured-media figcaption {

--- a/style.css
+++ b/style.css
@@ -1978,6 +1978,7 @@ body.template-cover .entry-header {
 
 .featured-media figcaption {
 	margin: 1.5rem auto 0 auto;
+	text-align: center;
 	width: calc( 100% - 5rem );
 }
 


### PR DESCRIPTION
This PR removes `width: 100%` from the post thumbnail image element. As noted in #84, setting the width to 100% will cause small images to look blurry, and the intent of the user could also have been to display a small image to begin with. Images smaller than the container are centered.

Since images can now take up less than the full with of the container, the PR also moves the pseudo element which creates the halfway up white background from the → 1000px media query to the base CSS, making it appear in all screen sizes.

Since images thinner than the container will now be displayed in the center of the container, the featured media caption has been updated to be centered as well.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/8181091/64490288-be6a3880-d25b-11e9-8cb1-b0bec58794a0.png">

Fixes #84.