### PR TITLE
Changed escape function

### DIFF
--- a/content.php
+++ b/content.php
@@ -71,7 +71,7 @@
 
 			<figure class="featured-media">
 
-				<div class="featured-media-inner section-inner<?php esc_attr_e( $featured_media_inner_classes ); ?>">
+				<div class="featured-media-inner section-inner<?php esc_attr( $featured_media_inner_classes ); ?>">
 
 					<?php 
 					


### PR DESCRIPTION
Changed the escape function used for `$featured_media_inner_classes` to use `esc_attr`

Fixes [#113](https://github.com/WordPress/twentytwenty/issues/113)


WordPress.org username - [hareesh-pillai](https://profiles.wordpress.org/hareesh-pillai/)