### PR TITLE
Remove custom styling for select elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -623,7 +623,6 @@ input[type="checkbox"] + label {
 
 input,
 textarea,
-select,
 button,
 .button,
 .faux-button,
@@ -636,7 +635,6 @@ button,
 @supports ( font-variation-settings: normal ) {
 	input,
 	textarea,
-	select,
 	button,
 	.button,
 	.faux-button,
@@ -647,8 +645,7 @@ button,
 }
 
 input,
-textarea,
-select {
+textarea {
 	border-color: #DCD7CA;
 }
 
@@ -666,7 +663,6 @@ input[type="number"],
 input[type="search"],
 input[type="tel"],
 input[type="color"],
-select,
 textarea {
 	-webkit-appearance: none;
 	-moz-appearance: none;
@@ -685,20 +681,14 @@ textarea {
 	width: 100%;
 }
 
+select {
+	font-size: 1em;
+}
+
 textarea {
 	height: 12rem;
 	line-height: 1.5;
 	width: 100%;
-}
-
-select {
-	background-repeat: no-repeat;
-	background-image: url( 'data:image/svg+xml;utf8,<svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="12" viewBox="0 0 20 12"><polygon fill="color( display-p3 0.102 0.106 0.122 / 1 )" fill-rule="evenodd" points="1319.899 365.778 1327.678 358 1329.799 360.121 1319.899 370.021 1310 360.121 1312.121 358" transform="translate(-1310 -358)" /></svg>');
-	background-position: calc( 100% - 2rem ) center;
-	background-size: 1.4rem .9rem;
-	line-height: 1.3;
-	padding: 1.4rem 4rem 1.4rem 1.8rem;
-	position: relative;
 }
 
 input::-webkit-input-placeholder { line-height: normal; }


### PR DESCRIPTION
Removes custom styling for `select` elements. Partly because of the issues with inconsistent display of the `data:image` chevron (see #120 and #86), but also because it will save us some time and effort down the road with RTL support, a11y concerns and other issues with inconsistent appearance in different browsers.

Removing the custom styling also benefits useability in that it makes the `select` elements more distinguishable from regular inputs.

Fixes #120.