### PR TITLE
Fixed: Use get_the_ID() insted of $post->ID

### DIFF
--- a/parts/page-header.php
+++ b/parts/page-header.php
@@ -37,7 +37,7 @@
 		} else {
 
 			// Default to displaying the post meta
-			twentytwenty_the_post_meta( $post->ID, 'single-top' );
+			twentytwenty_the_post_meta( get_the_ID(), 'single-top' );
 
 		}
 


### PR DESCRIPTION
Use get_the_ID() insted of $post->ID

<hr>

WordPress.org ID: mukesh27