### PR TITLE
Update coding standards

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -33,4 +33,17 @@
       <property name="is_theme" value="true"/>
     </properties>
   </rule>
+
+	<!-- Allow multiple parameters on one line for multi-line function calls. -->
+	<rule ref="PEAR.Functions.FunctionCallSignature">
+    <properties>
+       <property name="allowMultipleArguments" value="true" />
+    </properties>
+	</rule>
+
+	<!-- Improve code readablilty by allowing the artguments after function call. -->
+  <rule ref="PEAR.Functions.FunctionCallSignature">
+  	<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
+  	<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine"/>
+	</rule>
 </ruleset>


### PR DESCRIPTION
Exclude the `FunctionCallSignature` sniff which forces function arguments on the separate line

Improves readability of the code.