### PR TITLE
Show or hide commenter avatar

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -236,6 +236,9 @@ if ( ! function_exists( 'twentytwenty_body_classes' ) ) :
 			$classes[] = 'not-showing-comments';
 		}
 
+		// Check if avatars are visible
+		$classes[] = get_option( 'show_avatars' ) ? 'show-avatars' : 'hide-avatars';
+		
 		// Slim page template class names (class = name - file suffix)
 		if ( is_page_template() ) {
 			$classes[] = basename( get_page_template_slug(), '.php' );

--- a/style.css
+++ b/style.css
@@ -3397,6 +3397,10 @@ ul.footer-social li {
 		padding-left: 8rem;
 	}
 
+	.hide-avatars .comment-body {
+		padding-left: 0;
+	}
+
 	.comment-meta .avatar {
 		display: block;
 		height: 6rem;


### PR DESCRIPTION
Fix for #184

Adds two `body_class`es if either avatars are shown (`.show-avatars`) or hidden (`.hide-avatars`) for comment authors

----
WordPress.org username: acosmin