### PR TITLE
Update block styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -381,6 +381,10 @@ dfn {
 	font-style: italic;
 }
 
+em em, em i, i em, i i, cite em, cite i {
+	font-weight: bolder;
+}
+
 b,
 strong {
 	font-weight: 700;
@@ -412,9 +416,36 @@ address {
 }
 
 hr {
-	border: none;
-	border-top: .1rem solid #DCD7CA;
+	border-top: .1rem solid #B8B4A8; 
 	margin: 4rem 0;
+}
+
+hr:not(.is-style-dots):not(.reset-hr) {
+	background: linear-gradient( to left, #B8B4A8 calc( 50% - 16px ), transparent calc( 50% - 16px ), transparent calc( 50% + 16px ), #B8B4A8 calc( 50% + 16px ) );
+	border: none;
+	color: #B8B4A8;
+	height: .1rem;
+	position: relative;
+}
+
+hr:not(.is-style-dots):not(.reset-hr):before,
+hr:not(.is-style-dots):not(.reset-hr):after {
+	background: currentColor;
+	content: "";
+	display: block;
+	height: 1.6rem;
+	position: absolute;
+		top: calc( 50% - .8rem );
+	transform: rotate( 22.5deg );
+	width: .1rem;
+}
+
+hr:before {
+	left: calc( 50% - .5rem );
+}
+
+hr:after {
+	right: calc( 50% - .5rem );
 }
 
 a {
@@ -489,6 +520,7 @@ cite {
 	font-size: 1.4rem;
 	font-style: normal;
 	font-weight: 600;
+	line-height: 1.25;
 }
 
 blockquote cite {
@@ -678,7 +710,6 @@ textarea {
 	font-size: 1.6rem;
 	margin: 0;
 	max-width: 100%;
-	outline: none;
 	padding: 1.5rem 1.8rem;
 	width: 100%;
 }
@@ -2043,12 +2074,6 @@ body.template-cover .entry-header {
     font-weight: 800;
 }
 
-@supports ( font-variation-settings: normal ) {
-	.has-drop-cap:not(:focus):first-letter { 
-		font-family: 'Inter var', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, sans-serif; 
-	}
-}
-
 .has-drop-cap:not(:focus):first-letter:after {
     content: "";
     display: table;
@@ -2056,6 +2081,34 @@ body.template-cover .entry-header {
     padding-top: 14px
 }
 
+
+/* Block Font Families ----------------------- */
+
+.has-drop-cap:not(:focus):first-letter,
+.entry-content .wp-block-archives,
+.entry-content .wp-block-categories,
+.entry-content .wp-block-cover-image,
+.entry-content .wp-block-cover,
+.entry-content .wp-block-latest-comments,
+.entry-content .wp-block-latest-posts,
+.entry-content .wp-block-pullquote,
+.entry-content .wp-block-quote.is-large, 
+.entry-content .wp-block-quote.is-style-large {
+	font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, sans-serif;
+}
+
+@supports ( font-variation-settings: normal ) {
+	.has-drop-cap:not(:focus):first-letter,
+	.entry-content .wp-block-archives,
+	.entry-content .wp-block-categories,
+	.entry-content .wp-block-latest-posts,
+	.entry-content .wp-block-latest-comments,
+	.entry-content .wp-block-cover-image p,
+	.entry-content .wp-block-cover p,
+	.entry-content .wp-block-pullquote { 
+		font-family: 'Inter var', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, sans-serif; 
+	}
+}
 
 /* Block Font Sizes -------------------------- */
 
@@ -2068,11 +2121,21 @@ body.template-cover .entry-header {
 
 /* Block: Base Margins ----------------------- */
 
+.wp-block-archives:not(.aligncenter):not(.alignleft):not(.alignright),
+.wp-block-categories:not(.aligncenter):not(.alignleft):not(.alignright),
 .wp-block-columns:not(.alignwide):not(.alignfull),
 .wp-block-cover:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.aligncenter),
+.wp-block-embed:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.aligncenter),
+.wp-block-gallery:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.aligncenter),
 .wp-block-group:not(.alignwide):not(.alignfull),
+.wp-block-image:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.aligncenter),
+.wp-block-latest-comments:not(.aligncenter):not(.alignleft):not(.alignright),
+.wp-block-latest-posts:not(.aligncenter):not(.alignleft):not(.alignright),
 .wp-block-media-text:not(.alignwide):not(.alignfull),
-.wp-block-pullquote:not(.alignleft):not(.alignright):not(.alignwide):not(.alignfull) {
+.wp-block-pullquote:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.aligncenter),
+.wp-block-quote,
+.wp-block-quote.is-large, 
+.wp-block-quote.is-style-large {
 	margin-bottom: 3rem;
 	margin-top: 3rem;
 }
@@ -2080,27 +2143,70 @@ body.template-cover .entry-header {
 
 /* Block: Shared Widget Styles ----------------- */
 
-.entry-content .wp-block-archives,
-.entry-content .wp-block-categories,
-.entry-content .wp-block-latest-posts,
-.entry-content .wp-block-latest-comments {
-	font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, sans-serif;
+.wp-block-archives,
+.wp-block-categories,
+.wp-block-latest-posts,
+.wp-block-latest-comments {
+	list-style: none;
+	margin-left: 0;
 }
 
-@supports ( font-variation-settings: normal ) {
-	.entry-content .wp-block-archives,
-	.entry-content .wp-block-categories,
-	.entry-content .wp-block-latest-posts,
-	.entry-content .wp-block-latest-comments { 
-		font-family: 'Inter var', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, sans-serif; 
-	}
+.wp-block-archives ul,
+.wp-block-categories ul,
+.wp-block-latest-posts ul,
+.wp-block-latest-comments ul {
+	list-style: none;
 }
 
-.entry-content .wp-block-archives p,
-.entry-content .wp-block-categories p,
-.entry-content .wp-block-latest-posts p,
-.entry-content .wp-block-latest-comments p {
+.entry-content .wp-block-archives > li,
+.entry-content .wp-block-categories > li,
+.entry-content .wp-block-latest-posts > li,
+.entry-content .wp-block-latest-comment > li {
+	margin-left: 0;
+}
+
+.entry-content .wp-block-archives > li:last-child,
+.entry-content .wp-block-categories > li:last-child,
+.entry-content .wp-block-latest-posts > li:last-child,
+.entry-content .wp-block-latest-comment > li:last-child {
+	margin-bottom: 0;
+}
+
+.entry-content .wp-block-archives *,
+.entry-content .wp-block-categories *,
+.entry-content .wp-block-latest-posts *,
+.entry-content .wp-block-latest-comments * {
 	font-family: inherit;
+}
+
+.entry-content .wp-block-archives li, 
+.entry-content .wp-block-categories li, 
+.entry-content .wp-block-latest-posts li {
+	color: #6d6d6d;
+}
+
+.wp-block-archives a,
+.wp-block-categories a,
+.wp-block-latest-posts a,
+.wp-block-latest-comments a {
+	font-weight: 700;
+	text-decoration: none;
+}
+
+.wp-block-latest-posts a,
+.wp-block-latest-comments__comment-meta {
+	font-weight: 700;
+	letter-spacing: -0.025em;
+	line-height: 1.25;
+}
+
+.wp-block-latest-comments__comment-date,
+.wp-block-latest-posts__post-date {
+	color: #6d6d6d;
+	font-size: .7em;
+	font-weight: 600;
+	letter-spacing: normal;
+	margin-top: .15em;
 }
 
 
@@ -2120,26 +2226,24 @@ body.template-cover .entry-header {
     width: 100%;
 }
 
-
 /* Block: Button ----------------------------- */
 
 .wp-block-button.is-style-outline .wp-block-button__link {
 	color: inherit;
 }
 
+/* Block: Cover ------------------------------ */
 /* Block: Embed ------------------------------ */
-/* Block: Image ------------------------------ */
 /* Block: Gallery ---------------------------- */
 
 ul.wp-block-gallery:not(.alignwide):not(.alignfull):not(.alignright):not(.alignleft) {
 	margin-left: 0;
 }
 
-
 /* Block: Group ------------------------------ */
 
 .wp-block-group.has-background {
-	padding: 3rem 2rem;
+	padding: 2rem;
 }
 
 .wp-block-group__inner-container > *:first-child { margin-top: 0; }
@@ -2147,40 +2251,97 @@ ul.wp-block-gallery:not(.alignwide):not(.alignfull):not(.alignright):not(.alignl
 
 .wp-block-group__inner-container {
 	margin: 0 auto;
-	max-width: 58rem;
 }
 
+.wp-block-group__inner-container,
+.entry-content .wp-block-group p {
+	max-width: 100%;
+}
 
-/* Block: Media & Text ----------------------- */
+/* Block: Image ------------------------------ */
+/* Block: Media And Text --------------------- */
 
 .wp-block-media-text .wp-block-media-text__content {
-	padding-bottom: 3rem;
-	padding-top: 3rem;
+	padding: 3rem 2rem;
 }
 
+.wp-block-media-text .wp-block-media-text__content p {
+	max-width: none;
+}
+
+.wp-block-media-text__content > *:last-child {
+	margin-bottom: 0;
+}
 
 /* Block: Pullquote -------------------------- */
 
 /* STYLE: DEFAULT */
 
 .wp-block-pullquote {
-	font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, sans-serif;
 	padding: 0;
+	position: relative;
 }
 
-@supports ( font-variation-settings: normal ) {
-	.wp-block-pullquote { 
-		font-family: 'Inter var', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, sans-serif; 
-	}
+.wp-block-pullquote:before {
+	background: #fff;
+	border-radius: 50%;
+	color: #CD2653;
+	content: "”";
+	display: block;
+	font-size: 6.2rem;
+	font-weight: 500;
+	line-height: 1.2em;
+	margin: 0 auto 1.5rem auto;
+	text-align: center;
+	height: 4.4rem;
+	width: 4.4rem;
 }
 
 .wp-block-pullquote blockquote {
 	border: none;
+	margin: 0;
 	padding: 0;
 }
 
-.wp-block-pullquote p {
+.wp-block-pullquote blockquote p {
 	font-family: inherit;
+	font-size: 2.8rem;
+	font-weight: 700;
+	line-height: 1.178571429;
+	letter-spacing: -.041785714em;
+	max-width: 100%;
+}
+
+.wp-block-pullquote p:last-of-type {
+	margin-bottom: 0;
+}
+
+.wp-block-pullquote cite {
+	color: #6d6d6d;
+	font-size: 1.6rem;
+	font-weight: 500;
+	margin-top: 1.2rem;
+}
+
+.wp-block-pullquote.alignleft p, 
+.wp-block-pullquote.alignright p {
+	font-size: 2.8rem;
+}
+
+.wp-block-pullquote.alignleft {
+	text-align: left;
+}
+
+.wp-block-pullquote.alignright {
+	text-align: right;
+}
+
+.wp-block-pullquote.alignleft:before {
+	margin-left: 0;
+}
+
+.wp-block-pullquote.alignright:before {
+	margin-right: 0;
 }
 
 /* STYLE: SOLID BACKGROUND COLOR */
@@ -2189,8 +2350,59 @@ ul.wp-block-gallery:not(.alignwide):not(.alignfull):not(.alignright):not(.alignl
 	padding: 3rem 2rem;
 }
 
+.wp-block-pullquote.is-style-solid-color:before {
+	position: absolute;
+		top: 0;
+		left: 50%;
+	transform: translateY( -50% ) translateX( -50% );
+}
+
+.wp-block-pullquote.is-style-solid-color.alignleft:before,
+.wp-block-pullquote.is-style-solid-color.alignright:before {
+	transform: translateY( -50% );
+}
+
+.wp-block-pullquote.is-style-solid-color.alignleft:before {
+	left: 2rem;
+}
+
+.wp-block-pullquote.is-style-solid-color.alignright:before {
+	left: auto;
+	right: 2rem;
+}
+
+.wp-block-pullquote.is-style-solid-color blockquote {
+	max-width: 100%;
+	text-align: inherit;
+}
+
 .wp-block-pullquote.is-style-solid-color cite {
 	color: inherit;
+}
+
+/* Block: Separator  ------------------------- */
+
+hr.wp-block-separator {
+	margin: 3rem 0;
+}
+
+/* STYLE: WIDE */
+
+.wp-block-separator.is-style-wide {
+	max-width: calc( 100vw - 4rem );
+	position: relative;
+		left: calc( 50% - 50vw + 2rem );
+	width: calc( 100vw - 4rem );
+}
+
+/* STYLE: DOTS */
+
+.wp-block-separator.is-style-dots:before {
+	color: #B8B4A8;
+	font-size: 32px;
+	font-weight: 700;
+	letter-spacing: 1em;
+	padding-left: 1em;
 }
 
 
@@ -2200,6 +2412,15 @@ ul.wp-block-gallery:not(.alignwide):not(.alignfull):not(.alignright):not(.alignl
 	width: auto;
 }
 
+/* Block: Table ------------------------------ */
+
+.wp-block-table.is-style-stripes tr:nth-child(odd) {
+	background: rgba( 0, 0, 0, .05 );
+}
+
+.wp-block-table.is-style-stripes {
+	border-bottom-color: #DCD7CA;
+}
 
 /* Block: Quote ------------------------------ */
 
@@ -2220,6 +2441,78 @@ ul.wp-block-gallery:not(.alignwide):not(.alignfull):not(.alignright):not(.alignl
 
 /* STYLE: DEFAULT */
 /* STYLE: LARGE */
+
+.wp-block-quote.is-large, 
+.wp-block-quote.is-style-large {
+	border: none;
+	padding: 0;
+}
+
+.wp-block-quote.is-large p, 
+.wp-block-quote.is-style-large p {
+	font-family: inherit;
+	font-style: normal;
+	font-weight: 700;
+	letter-spacing: -.035714286em;
+	line-height: 1.285714286;
+}
+
+.wp-block-quote.is-large cite, 
+.wp-block-quote.is-large footer, 
+.wp-block-quote.is-style-large cite, 
+.wp-block-quote.is-style-large footer {
+	font-size: 1.6rem;
+	text-align: inherit;
+}
+
+/* Block: Widget Latest Comments ------------- */
+
+.entry-content .wp-block-latest-comments,
+.entry-content .wp-block-latest-comments li {
+	margin-left: 0;
+}
+
+.entry-content .wp-block-latest-comments a {
+	text-decoration: none;
+}
+
+.wp-block-latest-comments__comment {
+	font-size: inherit;
+}
+
+.wp-block-latest-comments__comment-date {
+	margin-top: .4em;
+}
+
+.wp-block-latest-comments__comment-excerpt p {
+	font-size: .7em;
+}
+
+/* Block: Widget Latest Posts ---------------- */
+
+.wp-block-latest-posts.is-grid,
+.wp-block-latest-posts.has-dates,
+.wp-block-latest-posts.has-dates li {
+	margin-left: 0;
+}
+
+.wp-block-latest-posts.is-grid li {
+	border-top: .2rem solid #DCD7CA;
+	margin-top: 2rem;
+	padding-top: 1rem;
+}
+
+.wp-block-latest-posts.has-dates {
+	list-style: none;
+}
+
+.wp-block-latest-posts.has-dates:not(.is-grid) li {
+	margin-top: 1.5rem;
+}
+
+.wp-block-latest-posts.has-dates:not(.is-grid) li:first-child {
+	margin-top: 0;
+}
 
 
 /* --------------------------------------------------------------------------------------------- */
@@ -2260,7 +2553,7 @@ ul.wp-block-gallery:not(.alignwide):not(.alignfull):not(.alignright):not(.alignl
 }
 
 .entry-content li {
-	margin: .5rem 2rem;
+	margin: .5rem 0 0 2rem;
 }
 
 .entry-content hr {
@@ -3014,6 +3307,26 @@ ul.footer-social li {
 /* --------------------------------------------------------------------------------------------- */
 
 
+@media ( min-width: 480px ) {
+
+	.alignleft,
+	.alignright,
+	.wp-block-pullquote.alignleft, 
+	.wp-block-pullquote.alignright,
+	.wp-block-cover-image.alignleft, 
+	.wp-block-cover-image.alignright,
+	.wp-block-cover.alignleft, 
+	.wp-block-cover.alignright,
+	.wp-block-embed.alignleft, 
+	.wp-block-embed.alignright,
+	.wp-block-gallery.alignleft, 
+	.wp-block-gallery.alignright {
+		max-width: 26rem
+	}
+
+
+}
+
 @media ( min-width: 700px ) {
 
 
@@ -3343,6 +3656,96 @@ ul.footer-social li {
 		font-size: 1.6rem;
 	}
 
+	/* BLOCK: BASE MARGINS */
+
+	.wp-block-archives:not(.aligncenter):not(.alignleft):not(.alignright),
+	.wp-block-categories:not(.aligncenter):not(.alignleft):not(.alignright),
+	.wp-block-columns:not(.alignwide):not(.alignfull),
+	.wp-block-cover:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.aligncenter),
+	.wp-block-embed:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.aligncenter),
+	.wp-block-gallery:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.aligncenter),
+	.wp-block-group:not(.alignwide):not(.alignfull),
+	.wp-block-image:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.aligncenter),
+	.wp-block-latest-comments:not(.aligncenter):not(.alignleft):not(.alignright),
+	.wp-block-latest-posts:not(.aligncenter):not(.alignleft):not(.alignright),
+	.wp-block-media-text:not(.alignwide):not(.alignfull),
+	.wp-block-pullquote:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright):not(.aligncenter),
+	.wp-block-quote,
+	.wp-block-quote.is-large, 
+	.wp-block-quote.is-style-large {
+		margin-bottom: 5rem;
+		margin-top: 5rem;
+	}
+
+	/* BLOCK: GROUP */
+
+	.wp-block-group.has-background {
+		padding: 4rem;
+	}
+
+	/* BLOCK: MEDIA AND TEXT */
+
+	.wp-block-media-text .wp-block-media-text__content {
+		padding: 4rem;
+	}
+
+	/* BLOCK: PULLQUOTE */
+
+	.wp-block-pullquote blockquote p {
+		font-size: 3.2rem;
+	}
+
+	.wp-block-pullquote cite {
+		margin-top: 2rem;
+	}
+
+	.wp-block-pullquote.alignfull:not(.is-style-solid-color) {
+		padding-left: 1rem;
+		padding-right: 1rem;
+	}
+
+	.wp-block-pullquote.alignwide:before,
+	.wp-block-pullquote.alignfull:before {
+		font-size: 11.272727272rem;
+		height: 8rem;
+		margin-bottom: 2rem;
+		width: 8rem;
+	}
+
+	.wp-block-pullquote.alignwide blockquote p,
+	.wp-block-pullquote.alignfull blockquote p {
+		font-size: 4.8rem;
+		line-height: 1.203125;
+	}
+
+	.wp-block-pullquote.alignleft p,
+	.wp-block-pullquote.alignright p {
+		font-size: 3.2rem;
+		line-height: 1.1875;
+	}
+
+	.wp-block-pullquote.is-style-solid-color.alignwide,
+	.wp-block-pullquote.is-style-solid-color.alignfull {
+		padding: 6rem 4rem 4rem;
+	}
+
+	.wp-block-pullquote.is-style-solid-color.alignleft p,
+	.wp-block-pullquote.is-style-solid-color.alignright p {
+		font-size: 2.6rem;
+	}
+
+	/* BLOCK: SEPARATOR */
+
+	hr.wp-block-separator {
+		margin: 6rem 0;
+	}
+
+	.wp-block-separator.is-style-wide {
+		max-width: calc( 100vw - 8rem );
+		left: calc( 50% - 50vw + 4rem );
+		width: calc( 100vw - 8rem );
+	}
+
 	/* Entry Content ------------------------- */
 
 	.entry-content {
@@ -3366,10 +3769,6 @@ ul.footer-social li {
 		margin: 4.5rem 0 2.5rem;
 	}
 
-	.entry-content hr {
-		margin: 8rem 0;
-	}
-
 	/* ALIGNMENT CLASSES */
 
 	.alignnone, 
@@ -3381,11 +3780,11 @@ ul.footer-social li {
 	}
 
 	.alignleft {
-		margin: .5rem 2.5rem 2.5rem 0;
+		margin-left: calc( ( 100vw - 58rem - 8rem ) / -2 );
 	}
 
 	.alignright {
-		margin: .5rem 0 2.5rem 2.5rem;
+		margin-right: calc( ( 100vw - 58rem - 8rem ) / -2 );
 	}
 
 	.alignwide {
@@ -3747,6 +4146,20 @@ ul.footer-social li {
 	/* Post: Archive ------------------------- */
 	/* Post: Single -------------------------- */
 	/* Blocks -------------------------------- */
+
+	/* BLOCK: GROUP */
+
+	.wp-block-group.alignwide.has-background,
+	.wp-block-group.alignfull.has-background {
+		padding: 8rem 4rem;
+	}
+
+	/* BLOCK: SEPARATOR */
+
+	hr.wp-block-separator {
+		margin: 8rem 0;
+	}
+
 	/* Entry Content ------------------------- */
 
 	/* ALIGNMENT CLASSES */
@@ -3891,6 +4304,26 @@ ul.footer-social li {
 	/* Post: Archive ------------------------- */
 	/* Post: Single -------------------------- */
 	/* Blocks -------------------------------- */
+
+	/* BLOCK: GROUP */
+
+	.wp-block-group.alignwide.has-background,
+	.wp-block-group.alignfull.has-background {
+		padding: 8rem 6rem;
+	}
+
+	/* BLOCK: PULLQUOTE */
+
+	.wp-block-pullquote.alignwide blockquote p,
+	.wp-block-pullquote.alignfull blockquote p {
+		font-size: 6.4rem;
+	}
+
+	.wp-block-pullquote.is-style-solid-color.alignwide,
+	.wp-block-pullquote.is-style-solid-color.alignfull {
+		padding: 9rem 4rem 8rem;
+	}
+
 	/* Entry Content ------------------------- */
 
 	/* ALIGNMENT CLASSES */
@@ -3935,14 +4368,61 @@ ul.footer-social li {
 
 @media ( min-width: 1280px ) {
 
+	/* Blocks -------------------------------- */
+
+	/* BLOCK: SEPARATOR */
+
+	.wp-block-separator.is-style-wide {
+		max-width: 120rem;
+		left: calc( 50% - 60rem );
+		width: 120rem;
+	}
+
 	/* Entry Content ------------------------- */
 
 	/* ALIGNMENT CLASSES */
+
+	.alignleft {
+		margin-left: -31rem;
+	}
+
+	.alignright {
+		margin-right: -31rem;
+	}
 
 	.alignwide {
 		max-width: 120rem;
 		left: calc( 50% - 60rem );
 		width: 120rem;
 	}
+
+}
+
+@media ( min-width: 1330px ) {
+
+
+	/* Blocks -------------------------------- */
+
+	/* BLOCK: PULLQUOTE */
+
+	.wp-block-pullquote.alignleft:before,
+	.wp-block-pullquote.alignright:before {
+		position: absolute;
+			top: -.4rem;
+	}
+
+	.wp-block-pullquote.is-style-solid-color.alignleft:before,
+	.wp-block-pullquote.is-style-solid-color.alignright:before {
+		top: 0;
+	}
+
+	.wp-block-pullquote.alignleft:before {
+		right: calc( 100% + 1.5rem );
+	}
+
+	.wp-block-pullquote.alignright:before {
+		left: calc( 100% + 1.5rem );
+	}
+
 
 }

--- a/style.css
+++ b/style.css
@@ -385,6 +385,10 @@ em em, em i, i em, i i, cite em, cite i {
 	font-weight: bolder;
 }
 
+big { font-style: 1.2em; }
+small { font-style: .75em; }
+
+
 b,
 strong {
 	font-weight: 700;
@@ -425,6 +429,7 @@ hr:not(.is-style-dots):not(.reset-hr) {
 	border: none;
 	color: #B8B4A8;
 	height: .1rem;
+	overflow: visible;
 	position: relative;
 }
 
@@ -540,7 +545,7 @@ kbd,
 pre,
 samp {
 	font-family: monospace;
-	font-size: 1em;
+	font-size: .9em;
 	padding: .4rem .6rem;
 }
 

--- a/style.css
+++ b/style.css
@@ -3307,26 +3307,6 @@ ul.footer-social li {
 /* --------------------------------------------------------------------------------------------- */
 
 
-@media ( min-width: 480px ) {
-
-	.alignleft,
-	.alignright,
-	.wp-block-pullquote.alignleft, 
-	.wp-block-pullquote.alignright,
-	.wp-block-cover-image.alignleft, 
-	.wp-block-cover-image.alignright,
-	.wp-block-cover.alignleft, 
-	.wp-block-cover.alignright,
-	.wp-block-embed.alignleft, 
-	.wp-block-embed.alignright,
-	.wp-block-gallery.alignleft, 
-	.wp-block-gallery.alignright {
-		max-width: 26rem
-	}
-
-
-}
-
 @media ( min-width: 700px ) {
 
 
@@ -3777,14 +3757,6 @@ ul.footer-social li {
 	.alignfull {
 		margin-bottom: 6rem;
 		margin-top: 6rem;
-	}
-
-	.alignleft {
-		margin-left: calc( ( 100vw - 58rem - 8rem ) / -2 );
-	}
-
-	.alignright {
-		margin-right: calc( ( 100vw - 58rem - 8rem ) / -2 );
 	}
 
 	.alignwide {
@@ -4381,14 +4353,6 @@ ul.footer-social li {
 	/* Entry Content ------------------------- */
 
 	/* ALIGNMENT CLASSES */
-
-	.alignleft {
-		margin-left: -31rem;
-	}
-
-	.alignright {
-		margin-right: -31rem;
-	}
 
 	.alignwide {
 		max-width: 120rem;

--- a/style.css
+++ b/style.css
@@ -420,14 +420,14 @@ address {
 }
 
 hr {
-	border-top: .1rem solid #B8B4A8; 
+	border-top: .1rem solid rgba( 0, 0, 0, .42 ); 
 	margin: 4rem 0;
 }
 
 hr:not(.is-style-dots):not(.reset-hr) {
-	background: linear-gradient( to left, #B8B4A8 calc( 50% - 16px ), transparent calc( 50% - 16px ), transparent calc( 50% + 16px ), #B8B4A8 calc( 50% + 16px ) );
+	background: linear-gradient( to left, rgba( 0, 0, 0, .42 ) calc( 50% - 16px ), transparent calc( 50% - 16px ), transparent calc( 50% + 16px ), rgba( 0, 0, 0, .42 ) calc( 50% + 16px ) );
 	border: none;
-	color: #B8B4A8;
+	color: rgba( 0, 0, 0, .42 );
 	height: .1rem;
 	overflow: visible;
 	position: relative;
@@ -2403,7 +2403,7 @@ hr.wp-block-separator {
 /* STYLE: DOTS */
 
 .wp-block-separator.is-style-dots:before {
-	color: #B8B4A8;
+	color: rgba( 0, 0, 0, .42 );
 	font-size: 32px;
 	font-weight: 700;
 	letter-spacing: 1em;


### PR DESCRIPTION
Includes a bunch of updates to the block-styles on the front-end (no editor styles).

## Block styles:
- Base block margins
- Pullquote
- Blockquote
- Widget blocks (Latest Posts, Archive, Recent Comments)
- Group block
- Separator block (fixes #254)

The block styles have been tested with the updates to the `.alignleft` and `.alignright` classes included in #236 and #237.

## Also:
- Added styling for nested emphasis (fixes #255)
- Removed removal of outline from base input styles (fixes #67, inputs with their own focus styles might need updating)
- Added styles for `big` and `small`, adjusted size of `code` (fixes #88)