### PR TITLE
Added missing top padding to 404 page

### DIFF
--- a/style.css
+++ b/style.css
@@ -2662,8 +2662,7 @@ div.comment:first-of-type {
 
 
 .error404 #site-content {
-	align-items: center;
-	display: flex;
+	padding-top: 4rem;
 	text-align: center;
 }
 
@@ -3499,6 +3498,12 @@ ul.footer-social li {
 	/* Display the full text for Newer and Older Posts. */
 	.nav-short {
 		display: inline;
+	}
+
+	/* Error 404 ----------------------------- */
+
+	.error404 #site-content {
+		padding-top: 8rem;
 	}
 
 	/* Widgets ------------------------------- */


### PR DESCRIPTION
Added top padding to the top of the 404 page, so it matches the structure of other pages. Fixes #263.

Before:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/8181091/64908934-d3d0de00-d705-11e9-8c5e-36f7513fd578.png">

After:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/8181091/64908937-e1866380-d705-11e9-8cc7-b1c0fddc53d0.png">