### PR TITLE
Update archive titles font-size to match design

### DIFF
--- a/404.php
+++ b/404.php
@@ -14,9 +14,9 @@ get_header();
 
 	<div class="section-inner thin">
 
-		<h1 class="archive-title"><?php esc_html_e( 'Page Not Found', 'twentytwenty' ); ?></h1>
+		<h1 class="entry-title"><?php esc_html_e( 'Page Not Found', 'twentytwenty' ); ?></h1>
 
-		<div class="intro-text archive-subtitle"><p><?php esc_html_e( 'The page you were looking for could not be found. It might have been removed, renamed, or did not exist in the first place.', 'twentytwenty' ); ?></p></div>
+		<div class="intro-text"><p><?php esc_html_e( 'The page you were looking for could not be found. It might have been removed, renamed, or did not exist in the first place.', 'twentytwenty' ); ?></p></div>
 
 		<?php get_search_form(); ?>
 

--- a/style.css
+++ b/style.css
@@ -1810,6 +1810,9 @@ body.template-cover .entry-header {
 }
 
 .archive-title {
+	font-size: 2.4rem;
+	font-weight: 700;
+	letter-spacing: -.026666667em;
 	margin: 0;
 }
 
@@ -3253,6 +3256,10 @@ ul.footer-social li {
 
 	.archive-header {
 		padding: 8rem 0;
+	}
+
+	.archive-title {
+		font-size: 3.2rem;
 	}
 
 	.posts {


### PR DESCRIPTION
Updates the `.archive-title` `font-size` value to match the design (`2.4rem` on mobile, `3.2rem` on → 700px).

Fixes #266.