### PR TITLE
Move html outside of translation in the 'continue reading...' text.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -503,10 +503,11 @@ if ( ! function_exists( 'twentytwenty_read_more_tag' ) ) {
 	 */
 	function twentytwenty_read_more_tag() {
 		return sprintf(
-			'<a href="%1$s" class="more-link">%2$s</a></p>',
+			'<a href="%1$s" class="more-link">%2$s <span class="screen-reader-text">"%3$s"</span></a></p>',
 			esc_url( get_permalink( get_the_ID() ) ),
 			/* Translators: %s: Name of current post */
-			sprintf( __( 'Continue reading <span class="screen-reader-text">"%s"</span>', 'twentytwenty' ), get_the_title( get_the_ID() ) )
+			esc_html( 'Continue reading', 'twentytwenty' ),
+			get_the_title( get_the_ID() )
 		);
 	}
 	add_filter( 'the_content_more_link', 'twentytwenty_read_more_tag' );


### PR DESCRIPTION
Moves some html outside of the translation function when forming the continue reading string.

Closes: #318 