### PR TITLE
Fix for twentytwenty_read_more_tag()

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -504,7 +504,7 @@ if ( ! function_exists( 'twentytwenty_read_more_tag' ) ) {
 	 */
 	function twentytwenty_read_more_tag() {
 		return sprintf(
-			'<a href="%1$s" class="more-link">%2$s <span class="screen-reader-text">"%3$s"</span></a></p>',
+			'<a href="%1$s" class="more-link">%2$s <span class="screen-reader-text">"%3$s"</span></a>',
 			esc_url( get_permalink( get_the_ID() ) ),
 			esc_html__( 'Continue reading', 'twentytwenty' ),
 			get_the_title( get_the_ID() )

--- a/functions.php
+++ b/functions.php
@@ -506,8 +506,7 @@ if ( ! function_exists( 'twentytwenty_read_more_tag' ) ) {
 		return sprintf(
 			'<a href="%1$s" class="more-link">%2$s <span class="screen-reader-text">"%3$s"</span></a></p>',
 			esc_url( get_permalink( get_the_ID() ) ),
-			/* Translators: %s: Name of current post */
-			esc_html( 'Continue reading', 'twentytwenty' ),
+			esc_html__( 'Continue reading', 'twentytwenty' ),
 			get_the_title( get_the_ID() )
 		);
 	}


### PR DESCRIPTION
Fix for #319 

- Wrong function for translation.
- the `Translators` comment isn't needed anymore.

@pattonwebz @carolinan 