### PR TITLE
UPDATE #322: Add accent color to next and previous post navigation

### DIFF
--- a/inc/custom-css.php
+++ b/inc/custom-css.php
@@ -82,7 +82,7 @@ if ( ! function_exists( 'twentytwenty_get_customizer_css' ) ) {
 			// Colors.
 			// Element Specific.
 			if ( $accent && $accent !== $accent_default ) {
-				twentytwenty_generate_css( 'a, .wp-block-button.is-style-outline, .has-drop-cap:not(:focus):first-letter', 'color', $accent );
+				twentytwenty_generate_css( 'a, .wp-block-button.is-style-outline, .has-drop-cap:not(:focus):first-letter, a.previous-post, a.next-post', 'color', $accent );
 				twentytwenty_generate_css( 'blockquote, .wp-block-button.is-style-outline', 'border-color', $accent );
 				twentytwenty_generate_css( $buttons_targets, 'background-color', $accent );
 				twentytwenty_generate_css( '.footer-social a, .social-icons a', 'background-color', $accent );


### PR DESCRIPTION
Fixes #322 

<table>
<tr>
<td>Before:
<br><br>

![#322 - before](https://user-images.githubusercontent.com/3323310/65046353-74094b80-d92e-11e9-8634-f5ea932ea214.png)

</td>
<td>After:
<br><br>

![#322 - after](https://user-images.githubusercontent.com/3323310/65046355-77043c00-d92e-11e9-92b9-931506384086.png)

</td>
</tr>
</table>