### PR TITLE
Issue/29 2/async defer javascript

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,3 +35,4 @@ Version 1.0:
 | @vbaimas | @vbaimas |
 | @ZebulanStanphill | @zebulan |
 | @byalextran | @byalextran |
+| @mor10 | @mor10 |

--- a/classes/class-twentytwenty-script-loader.php
+++ b/classes/class-twentytwenty-script-loader.php
@@ -1,10 +1,19 @@
 <?php
+/**
+ * Javsscript Loader Class
+ *
+ * Allow `async` and `defer` while enqueuing Javascript.
+ *
+ * Based on a soltion in WP Rig.
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty
+ * @since 1.0.0
+ */
 
-/* ---------------------------------------------------------------------------------------------
-   JAVASCRIPT LOADER CLASS
-   Allow `async` and `defer` while enqueueing JavaScript. Based on a solution in WP Rig. 
-   --------------------------------------------------------------------------------------------- */
-
+/**
+ * A class that provides a way to add `async` or `defer` attributes to scripts.
+ */
 class TwentyTwenty_Script_Loader {
 
 	/**
@@ -32,8 +41,8 @@ class TwentyTwenty_Script_Loader {
 		}
 		return $tag;
 	}
-	
+
 }
 
-$loader = new TwentyTwenty_Script_Loader;
+$loader = new TwentyTwenty_Script_Loader();
 add_filter( 'script_loader_tag', [ $loader, 'filter_script_loader_tag' ], 10, 2 );

--- a/classes/class-twentytwenty-script-loader.php
+++ b/classes/class-twentytwenty-script-loader.php
@@ -43,6 +43,3 @@ class TwentyTwenty_Script_Loader {
 	}
 
 }
-
-$loader = new TwentyTwenty_Script_Loader();
-add_filter( 'script_loader_tag', [ $loader, 'filter_script_loader_tag' ], 10, 2 );

--- a/classes/class-twentytwenty-script-loader.php
+++ b/classes/class-twentytwenty-script-loader.php
@@ -27,7 +27,7 @@ class TwentyTwenty_Script_Loader {
 	 * @param string $handle The script handle.
 	 * @return string Script HTML string.
 	 */
-	public function filter_script_loader_tag( string $tag, string $handle ) : string {
+	public function filter_script_loader_tag( $tag, $handle ) {
 		foreach ( [ 'async', 'defer' ] as $attr ) {
 			if ( ! wp_scripts()->get_data( $handle, $attr ) ) {
 				continue;

--- a/functions.php
+++ b/functions.php
@@ -120,6 +120,13 @@ if ( ! function_exists( 'twentytwenty_theme_support' ) ) {
 		// Add support for full and wide align images.
 		add_theme_support( 'align-wide' );
 
+		/*
+		 * Adds `async` and `defer` support for scripts registered or enqueued
+		 * by the theme.
+		 */
+		$loader = new TwentyTwenty_Script_Loader();
+		add_filter( 'script_loader_tag', [ $loader, 'filter_script_loader_tag' ], 10, 2 );
+
 	}
 
 	add_action( 'after_setup_theme', 'twentytwenty_theme_support' );

--- a/functions.php
+++ b/functions.php
@@ -151,6 +151,9 @@ require get_template_directory() . '/classes/class-twentytwenty-walker-page.php'
 // Color calculations.
 require get_template_directory() . '/classes/class-twentytwenty-color.php';
 
+// Custom script loader class.
+require get_template_directory() . '/classes/class-twentytwenty-script-loader.php';
+
 // Custom CSS.
 require get_template_directory() . '/inc/custom-css.php';
 

--- a/functions.php
+++ b/functions.php
@@ -208,7 +208,7 @@ if ( ! function_exists( 'twentytwenty_register_scripts' ) ) {
 		$js_dependencies = array( 'jquery' );
 
 		wp_enqueue_script( 'twentytwenty-construct', get_template_directory_uri() . '/assets/js/construct.js', $js_dependencies, $theme_version, false );
-
+		wp_script_add_data( 'twentytwenty-construct', 'async', true );
 	}
 
 	add_action( 'wp_enqueue_scripts', 'twentytwenty_register_scripts' );

--- a/parts/classes/class-script-loader.php
+++ b/parts/classes/class-script-loader.php
@@ -1,0 +1,39 @@
+<?php
+
+/* ---------------------------------------------------------------------------------------------
+   JAVASCRIPT LOADER CLASS
+   Allow `async` and `defer` while enqueueing JavaScript. Based on a solution in WP Rig. 
+   --------------------------------------------------------------------------------------------- */
+
+class TwentyTwenty_Script_Loader {
+
+	/**
+	 * Adds async/defer attributes to enqueued / registered scripts.
+	 *
+	 * If #12009 lands in WordPress, this function can no-op since it would be handled in core.
+	 *
+	 * @link https://core.trac.wordpress.org/ticket/12009
+	 *
+	 * @param string $tag    The script tag.
+	 * @param string $handle The script handle.
+	 * @return string Script HTML string.
+	 */
+	public function filter_script_loader_tag( string $tag, string $handle ) : string {
+		foreach ( [ 'async', 'defer' ] as $attr ) {
+			if ( ! wp_scripts()->get_data( $handle, $attr ) ) {
+				continue;
+			}
+			// Prevent adding attribute when already added in #12009.
+			if ( ! preg_match( ":\s$attr(=|>|\s):", $tag ) ) {
+				$tag = preg_replace( ':(?=></script>):', " $attr", $tag, 1 );
+			}
+			// Only allow async or defer, not both.
+			break;
+		}
+		return $tag;
+	}
+	
+}
+
+$loader = new TwentyTwenty_Script_Loader;
+add_filter( 'script_loader_tag', [ $loader, 'filter_script_loader_tag' ], 10, 2 );


### PR DESCRIPTION
This updates #30 to move the class to the `classes` folder, remove the return type on the function and moves the instantiation and filter add to be beside other theme-support type items.

Will close: #29 