### PR TITLE
UPDATE #344: Centre `Continue Reading` button

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -506,7 +506,7 @@ if ( ! function_exists( 'twentytwenty_read_more_tag' ) ) {
 	 */
 	function twentytwenty_read_more_tag() {
 		return sprintf(
-			'<a href="%1$s" class="more-link faux-button">%2$s <span class="screen-reader-text">"%3$s"</span></a>',
+			'<p class="has-text-align-center"><a href="%1$s" class="more-link faux-button">%2$s <span class="screen-reader-text">"%3$s"</span></a></p>',
 			esc_url( get_permalink( get_the_ID() ) ),
 			esc_html__( 'Continue reading', 'twentytwenty' ),
 			get_the_title( get_the_ID() )


### PR DESCRIPTION
Fixes #344 

<table>
<tr>
<td>Before:
<br><br>

![#344 - before](https://user-images.githubusercontent.com/3323310/65173346-de191200-da4e-11e9-969b-e1845ed8c987.png)

</td>
<td>After:
<br><br>

![#344 - after](https://user-images.githubusercontent.com/3323310/65173362-e1140280-da4e-11e9-9c74-8e449d2da2c4.png)

</td>
</tr>
</table>