### PR TITLE
JS TypeError fix when search modal is not enabled

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -202,11 +202,11 @@ twentytwenty.focusManagement = {
 			var menuModal = document.querySelector('.menu-modal');
 			var headerToggles = document.querySelector('.header-toggles');
 			var searchModal = document.querySelector('.search-modal');
-			if (menuModal.classList.contains('.active')) {
-				if (!menuModal.contains(element) && !headerToggles.contains(element)) {
+			if (menuModal && menuModal.classList.contains('.active')) {
+				if (!menuModal.contains(element) && headerToggles && !headerToggles.contains(element)) {
 					document.querySelector('.nav-toggle').focus();
 				}
-			} else if (!searchModal.classList.contains('.active')) {
+			} else if (searchModal && !searchModal.classList.contains('.active')) {
 				if (!searchModal.contains(element)) {
 					searchModal.querySelector('.search-field').focus();
 				}


### PR DESCRIPTION
If `Show search in header` is not enabled and you click on any actionable item (like the menu toggle), the console will output: `Uncaught TypeError: Cannot read property 'classList' of null at HTMLDocument.<anonymous> (VM6903 index.js:209)`

This PR will fix that, it also adds checks for the other queried Elements.