### PR TITLE
Update `.editorconfig` to latest WordPress version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,6 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.txt]
+end_of_line = crlf

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,12 +13,9 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
 
-[{package.json,*.yml}]
+[*.yml]
 indent_style = space
 indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
-
-[*.txt]
-end_of_line = crlf


### PR DESCRIPTION
This updates the `.editorconfig` to the latest WordPress version:

https://core.trac.wordpress.org/browser/trunk/.editorconfig