### PR TITLE
WPCS : Remove twentytwentyGetQueryStringValue() 

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -551,18 +551,6 @@ function twentytwentyToggleAttribute( element, attribute, trueVal, falseVal ) {
 	}
 }
 
-function twentytwentyGetQueryStringValue() {
-	const vars = [];
-	let hash;
-	const hashes = window.location.href.slice( window.location.href.indexOf( '?' ) + 1 ).split( '&' );
-	for ( let i = 0; i < hashes.length; i++ ) {
-		hash = hashes[ i ].split( '=' );
-		vars.push( hash[ 0 ] );
-		vars[ hash[ 0 ] ] = hash[ 1 ];
-	}
-	return vars;
-}
-
 /**
  * twentytwentySlideUp
  *


### PR DESCRIPTION
While looking at https://github.com/WordPress/twentytwenty/pull/363, I found that the Travis CI complain about this function being unused. I did a manual search, and confirmed that it is not used anywhere.