### PR TITLE
Update readme with licensing information for Inter and FontAwesome

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ Image in screenshot.png from PxHere
 License: Creative Commons Zero (CC0), https://creativecommons.org/publicdomain/zero/1.0/
 URL: https://pxhere.com/en/photo/18153
 
+Inter Font
+License: SIL Open Font License, 1.1, https://opensource.org/licenses/OFL-1.1
+Source: https://rsms.me/inter/
+
+FontAwesome Icons
+License: SIL Open Font License, 1.1, https://opensource.org/licenses/OFL-1.1
+Source: https://www.fontawesome.io
+
+FontAwesome Code
+License: MIT License, https://opensource.org/licenses/MIT
+Source: https://www.fontawesome.io
+
 Font Noto Sans 
 License: Apache License (Apache-2.0), https://www.apache.org/licenses/LICENSE-2.0
 URL: https://fonts.google.com/specimen/Noto+Sans

--- a/readme.txt
+++ b/readme.txt
@@ -19,6 +19,18 @@ Image in screenshot.png from PxHere
 License: Creative Commons Zero (CC0), https://creativecommons.org/publicdomain/zero/1.0/
 URL: https://pxhere.com/en/photo/18153
 
+Inter Font
+License: SIL Open Font License, 1.1, https://opensource.org/licenses/OFL-1.1
+Source: https://rsms.me/inter/
+
+FontAwesome Icons
+License: SIL Open Font License, 1.1, https://opensource.org/licenses/OFL-1.1
+Source: https://www.fontawesome.io
+
+FontAwesome Code
+License: MIT License, https://opensource.org/licenses/MIT
+Source: https://www.fontawesome.io
+
 Font Noto Sans 
 License: Apache License (Apache-2.0), https://www.apache.org/licenses/LICENSE-2.0
 URL: https://fonts.google.com/specimen/Noto+Sans


### PR DESCRIPTION
Updates `readme.md` and `readme.txt` to include:

```
Inter Font
License: SIL Open Font License, 1.1, https://opensource.org/licenses/OFL-1.1
Source: https://rsms.me/inter/

FontAwesome Icons
License: SIL Open Font License, 1.1, https://opensource.org/licenses/OFL-1.1
Source: https://www.fontawesome.io

FontAwesome Code
License: MIT License, https://opensource.org/licenses/MIT
Source: https://www.fontawesome.io
```