### PR TITLE
#391 Fix - Display consistent social links on footer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -26,10 +26,9 @@
 
 				$footer_top_classes .= $has_footer_menu ? ' has-footer-menu' : '';
 				$footer_top_classes .= $has_social_menu ? ' has-social-menu' : '';
+				$footer_social_wrapper_class = $has_footer_menu ? 'footer-social-wrapper' : '';
 
-				if ( $has_footer_menu || $has_social_menu ) {
-
-				?>
+				if ( $has_footer_menu || $has_social_menu ) { ?>
 					<div class="footer-top<?php echo esc_attr( $footer_top_classes ); ?>">
 						<?php if ( $has_footer_menu ) { ?>
 
@@ -39,9 +38,9 @@
 									<?php
 									wp_nav_menu(
 										array(
-											'container'      => '',
-											'depth'          => 1,
-											'items_wrap'     => '%3$s',
+											'container' => '',
+											'depth' => 1,
+											'items_wrap' => '%3$s',
 											'theme_location' => 'footer',
 										)
 									);
@@ -53,7 +52,7 @@
 						<?php } ?>
 						<?php if ( $has_social_menu ) { ?>
 
-							<div class="footer-social-wrapper">
+							<div class="<?php esc_attr( $footer_social_wrapper_class ); ?>">
 
 								<nav aria-label="<?php esc_attr_e( 'Social links', 'twentytwenty' ); ?>">
 
@@ -120,14 +119,14 @@
 
 					<div class="footer-credits">
 
-						<p class="footer-copyright">&copy; 
-							<?php 
-							echo esc_html( 
-								date_i18n( 
+						<p class="footer-copyright">&copy;
+							<?php
+							echo esc_html(
+								date_i18n(
 									/* Translators: Y = Format parameter for date() https://php.net/manual/en/function.date.php */
-									_x( 'Y', 'Translators: Y = Current year', 'twentytwenty' ) 
-								) 
-							); 
+									_x( 'Y', 'Translators: Y = Current year', 'twentytwenty' )
+								)
+							);
 							?>
 							<a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php echo bloginfo( 'name' ); ?></a></a>
 						</p>

--- a/footer.php
+++ b/footer.php
@@ -27,28 +27,30 @@
 				$footer_top_classes .= $has_footer_menu ? ' has-footer-menu' : '';
 				$footer_top_classes .= $has_social_menu ? ' has-social-menu' : '';
 
-				if ( $has_footer_menu ) {
-					?>
+				if ( $has_footer_menu || $has_social_menu ) {
 
+				?>
 					<div class="footer-top<?php echo esc_attr( $footer_top_classes ); ?>">
+						<?php if ( $has_footer_menu ) { ?>
 
-						<nav aria-label="<?php esc_attr_e( 'Footer menu', 'twentytwenty' ); ?>">
+							<nav aria-label="<?php esc_attr_e( 'Footer menu', 'twentytwenty' ); ?>">
 
-							<ul class="footer-menu reset-list-style">
-								<?php
-								wp_nav_menu(
-									array(
-										'container'      => '',
-										'depth'          => 1,
-										'items_wrap'     => '%3$s',
-										'theme_location' => 'footer',
-									)
-								);
-								?>
-							</ul>
+								<ul class="footer-menu reset-list-style">
+									<?php
+									wp_nav_menu(
+										array(
+											'container'      => '',
+											'depth'          => 1,
+											'items_wrap'     => '%3$s',
+											'theme_location' => 'footer',
+										)
+									);
+									?>
+								</ul>
 
-						</nav><!-- .site-nav -->
+							</nav><!-- .site-nav -->
 
+						<?php } ?>
 						<?php if ( $has_social_menu ) { ?>
 
 							<div class="footer-social-wrapper">
@@ -81,10 +83,10 @@
 							</div><!-- .footer-social-wrapper -->
 
 						<?php } ?>
-
 					</div><!-- .footer-top -->
 
 				<?php } ?>
+
 
 				<?php if ( is_active_sidebar( 'footer-one' ) || is_active_sidebar( 'footer-two' ) ) { ?>
 

--- a/footer.php
+++ b/footer.php
@@ -24,8 +24,9 @@
 
 				$footer_top_classes = '';
 
-				$footer_top_classes .=         $has_footer_menu ? ' has-footer-menu' : '';
-				$footer_top_classes .=         $has_social_menu ? ' has-social-menu' : '';
+				$footer_top_classes .= $has_footer_menu ? ' has-footer-menu' : '';
+				$footer_top_classes .= $has_social_menu ? ' has-social-menu' : '';
+
 				$footer_social_wrapper_class = $has_footer_menu ? 'footer-social-wrapper' : '';
 
 				if ( $has_footer_menu || $has_social_menu ) {

--- a/footer.php
+++ b/footer.php
@@ -24,11 +24,12 @@
 
 				$footer_top_classes = '';
 
-				$footer_top_classes .= $has_footer_menu ? ' has-footer-menu' : '';
-				$footer_top_classes .= $has_social_menu ? ' has-social-menu' : '';
+				$footer_top_classes .=         $has_footer_menu ? ' has-footer-menu' : '';
+				$footer_top_classes .=         $has_social_menu ? ' has-social-menu' : '';
 				$footer_social_wrapper_class = $has_footer_menu ? 'footer-social-wrapper' : '';
 
-				if ( $has_footer_menu || $has_social_menu ) { ?>
+				if ( $has_footer_menu || $has_social_menu ) {
+					?>
 					<div class="footer-top<?php echo esc_attr( $footer_top_classes ); ?>">
 						<?php if ( $has_footer_menu ) { ?>
 
@@ -38,8 +39,8 @@
 									<?php
 									wp_nav_menu(
 										array(
-											'container' => '',
-											'depth' => 1,
+											'container'  => '',
+											'depth'      => 1,
 											'items_wrap' => '%3$s',
 											'theme_location' => 'footer',
 										)


### PR DESCRIPTION


Footer only with social links:
![Screenshot 2019-09-21 at 16 59 42](https://user-images.githubusercontent.com/37012961/65375164-a6021100-dc92-11e9-8cd5-614f5e303170.png)
Should we move with CSS the links to the right?

Footer with both menu and social links:
![Screenshot 2019-09-21 at 16 59 20](https://user-images.githubusercontent.com/37012961/65375166-a7333e00-dc92-11e9-8fe5-fe3618dd98e4.png)

Footer with no footer menu or social links
![Screenshot 2019-09-21 at 17 00 29](https://user-images.githubusercontent.com/37012961/65375162-a4384d80-dc92-11e9-885b-1efb45ed6fbd.png)


