### PR TITLE
Add a searchform.php template

### DIFF
--- a/404.php
+++ b/404.php
@@ -18,7 +18,13 @@ get_header();
 
 		<div class="intro-text"><p><?php _e( 'The page you were looking for could not be found. It might have been removed, renamed, or did not exist in the first place.', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></p></div>
 
-		<?php get_search_form(); ?>
+		<?php
+		get_search_form(
+			array(
+				'label' => __( '404 not found', 'twentytwenty' ),
+			)
+		);
+		?>
 
 	</div><!-- .section-inner -->
 

--- a/index.php
+++ b/index.php
@@ -87,7 +87,13 @@ get_header();
 
 			<div class="no-search-results-form section-inner thin">
 
-				<?php get_search_form(); ?>
+				<?php
+				get_search_form(
+					array(
+						'label' => __( 'search again', 'twentytwenty' ),
+					)
+				);
+				?>
 
 			</div><!-- .no-search-results -->
 

--- a/searchform.php
+++ b/searchform.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * The searchform.php template.
+ *
+ * Used any time that get_serach_form() is called.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty
+ * @since 1.0.0
+ */
+
+/*
+ * Generate a unique ID for each form and a string containing an aria-label if
+ * one was passed to get_search_form() in the args array.
+ */
+$unique_id  = uniqid( 'search-form-' );
+$aria_label = ( isset( $args['label'] ) && ! empty( $args['label'] ) ) ? 'aria-label="' . esc_attr( $args['label'] ) . '"' : '';
+?>
+<form role="search" <?php echo $aria_label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above. ?> method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+	<label for="<?php echo esc_attr( $unique_id ); ?>">
+		<span class="screen-reader-text"><?php echo _x( 'Search for:', 'label', 'twentytwenty' ); // phpcs:ignore: WordPress.Security.EscapeOutput.OutputNotEscaped -- core trusts translations ?></span>
+		<input type="search" id="<?php echo esc_attr( $unique_id ); ?>" class="search-field" placeholder="<?php echo esc_attr_x( 'Search &hellip;', 'placeholder', 'twentytwenty' ); ?>" value="<?php get_search_query(); ?>" name="s" />
+	</label>
+	<input type="submit" class="search-submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'twentytwenty' ); ?>" />
+</form>


### PR DESCRIPTION
Adds a first searchform.php template that gets used in the 404 template and the 'no posts found' search template. Labels and `aria-*` could use improvements.

The modal search form is unchanged by this PR. The styles on the other search also is unchanged. I've attached screenshots of the other searches in a widget, the no post found block and the 404 search block.

![Screenshot from 2019-09-22 01-34-48](https://user-images.githubusercontent.com/3902039/65380732-61e62f00-dcd9-11e9-9de1-d1b4880c420e.png)
![Screenshot from 2019-09-22 01-34-52](https://user-images.githubusercontent.com/3902039/65380733-627ec580-dcd9-11e9-97b6-d94daef3ed9c.png)
![Screenshot from 2019-09-22 01-35-38](https://user-images.githubusercontent.com/3902039/65380734-627ec580-dcd9-11e9-9cf3-37dafc74de04.png)


