### PR TITLE
Fix - Global JS variables should be prefixed

### DIFF
--- a/assets/js/customize-controls.js
+++ b/assets/js/customize-controls.js
@@ -1,4 +1,4 @@
-/* global backgroundColors, twentyTwentyColor, Color, jQuery, wp, _ */
+/* global twentyTwentyBgColors, twentyTwentyColor, Color, jQuery, wp, _ */
 /**
  * Customizer enhancements for a better user experience.
  *
@@ -14,12 +14,12 @@
 		wp.customize( 'accent_hue', function( value ) {
 			value.bind( function( to ) {
 				// Update the value for our accessible colors for all areas.
-				Object.keys( backgroundColors ).forEach( function( context ) {
+				Object.keys( twentyTwentyBgColors ).forEach( function( context ) {
 					var backgroundColorValue;
-					if ( backgroundColors[ context ].color ) {
-						backgroundColorValue = backgroundColors[ context ].color;
+					if ( twentyTwentyBgColors[ context ].color ) {
+						backgroundColorValue = twentyTwentyBgColors[ context ].color;
 					} else {
-						backgroundColorValue = wp.customize( backgroundColors[ context ].setting ).get();
+						backgroundColorValue = wp.customize( twentyTwentyBgColors[ context ].setting ).get();
 					}
 					twentyTwentySetAccessibleColorsValue( context, backgroundColorValue, to );
 				} );
@@ -27,8 +27,8 @@
 		} );
 
 		// Add a listener for background-color changes.
-		Object.keys( backgroundColors ).forEach( function( context ) {
-			wp.customize( backgroundColors[ context ].setting, function( value ) {
+		Object.keys( twentyTwentyBgColors ).forEach( function( context ) {
+			wp.customize( twentyTwentyBgColors[ context ].setting, function( value ) {
 				value.bind( function( to ) {
 					// Update the value for our accessible colors for this area.
 					twentyTwentySetAccessibleColorsValue( context, to, wp.customize( 'accent_hue' ).get(), to );

--- a/assets/js/customize-preview.js
+++ b/assets/js/customize-preview.js
@@ -1,4 +1,4 @@
-/* global backgroundColors, previewElements, jQuery, _, wp */
+/* global twentyTwentyBgColors, twentyTwentyPreviewEls, jQuery, _, wp */
 /**
  * Customizer enhancements for a better user experience.
  *
@@ -22,7 +22,7 @@
 			// Generate the styles.
 			// Add a small delay to be sure the accessible colors were generated.
 			setTimeout( function() {
-				Object.keys( backgroundColors ).forEach( function( context ) {
+				Object.keys( twentyTwentyBgColors ).forEach( function( context ) {
 					twentyTwentyGenerateColorA11yPreviewStyles( context );
 				} );
 			}, 50 );
@@ -30,8 +30,8 @@
 	} );
 
 	// Add listeners for background-color settings.
-	Object.keys( backgroundColors ).forEach( function( context ) {
-		wp.customize( backgroundColors[ context ].setting, function( value ) {
+	Object.keys( twentyTwentyBgColors ).forEach( function( context ) {
+		wp.customize( twentyTwentyBgColors[ context ].setting, function( value ) {
 			value.bind( function() {
 				// Generate the styles.
 				// Add a small delay to be sure the accessible colors were generated.
@@ -64,8 +64,8 @@
 		}
 		if ( ! _.isUndefined( a11yColors[ context ] ) ) {
 			// Check if we have elements defined.
-			if ( previewElements[ context ] ) {
-				_.each( previewElements[ context ], function( items, setting ) {
+			if ( twentyTwentyPreviewEls[ context ] ) {
+				_.each( twentyTwentyPreviewEls[ context ], function( items, setting ) {
 					_.each( items, function( elements, property ) {
 						if ( ! _.isUndefined( a11yColors[ context ][ setting ] ) ) {
 							styles += elements.join( ',' ) + '{' + property + ':' + a11yColors[ context ][ setting ] + ';}';

--- a/functions.php
+++ b/functions.php
@@ -560,7 +560,7 @@ if ( ! function_exists( 'twentytwenty_customize_controls_enqueue_scripts' ) ) {
 
 		// Add script for controls.
 		wp_enqueue_script( 'twentytwenty-customize-controls', get_template_directory_uri() . '/assets/js/customize-controls.js', array( 'twentytwenty-color-calculations', 'customize-controls', 'underscore', 'jquery' ), $theme_version, false );
-		wp_localize_script( 'twentytwenty-customize-controls', 'backgroundColors', twentytwenty_get_customizer_color_vars() );
+		wp_localize_script( 'twentytwenty-customize-controls', 'twentyTwentyBgColors', twentytwenty_get_customizer_color_vars() );
 	}
 
 	add_action( 'customize_controls_enqueue_scripts', 'twentytwenty_customize_controls_enqueue_scripts' );
@@ -578,8 +578,8 @@ if ( ! function_exists( 'twentytwenty_customize_preview_init' ) ) {
 		$theme_version = wp_get_theme()->get( 'Version' );
 
 		wp_enqueue_script( 'twentytwenty-customize-preview', get_theme_file_uri( '/assets/js/customize-preview.js' ), array( 'customize-preview', 'jquery' ), $theme_version, true );
-		wp_localize_script( 'twentytwenty-customize-preview', 'backgroundColors', twentytwenty_get_customizer_color_vars() );
-		wp_localize_script( 'twentytwenty-customize-preview', 'previewElements', twentytwenty_get_elements_array() );
+		wp_localize_script( 'twentytwenty-customize-preview', 'twentyTwentyBgColors', twentytwenty_get_customizer_color_vars() );
+		wp_localize_script( 'twentytwenty-customize-preview', 'twentyTwentyPreviewEls', twentytwenty_get_elements_array() );
 	}
 
 	add_action( 'customize_preview_init', 'twentytwenty_customize_preview_init' );


### PR DESCRIPTION
Prefixed  `previewElements` and `backgroundColors`

Fix for #522