### PR TITLE
Update `package.json` format per WordPress Coding Standards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,3 +52,6 @@ script:
 
   # Run the theme through lint:css checker as defined in @wordpress/scripts package.
   - if [[ "$PHPCS" == 1 ]]; then npm run lint:css; fi
+
+  # Run the theme through lint:pkg-json checker as defined in @wordpress/scripts package.
+  - if [[ "$PHPCS" == 1 ]]; then npm run lint:pkg-json; fi

--- a/package.json
+++ b/package.json
@@ -2,15 +2,21 @@
 	"name": "twentytwenty",
 	"version": "1.0.0",
 	"description": "Default WP Theme",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"WordPress",
+		"Theme",
+		"TwentyTwenty"
+	],
+	"homepage": "https://github.com/wordpress/twentytwenty#readme",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/wordpress/twentytwenty.git"
 	},
-	"license": "GPL-2.0+",
 	"bugs": {
 		"url": "https://github.com/wordpress/twentytwenty/issues"
 	},
-	"homepage": "https://github.com/wordpress/twentytwenty#readme",
 	"devDependencies": {
 		"@wordpress/scripts": "^5.0.0",
 		"concurrently": "^4.1.2",
@@ -35,6 +41,7 @@
 		"build:rtl-esb": "rtlcss assets/css/editor-style-block.css assets/css/editor-style-block-rtl.css",
 		"build:rtl-esc": "rtlcss assets/css/editor-style-classic.css assets/css/editor-style-classic-rtl.css",
 		"lint:css": "wp-scripts lint-style 'style.css' 'assets/**/*.css'",
-		"lint:js": "wp-scripts lint-js 'assets/**/*.js'"
+		"lint:js": "wp-scripts lint-js 'assets/**/*.js'",
+		"lint:pkg-json": "wp-scripts lint-pkg-json"
 	}
 }


### PR DESCRIPTION
Another follow up to the _build tools_ update in #363

This updates the `package.json` format to match that of the WordPress Coding Standards

https://github.com/WordPress/gutenberg/tree/master/packages/npm-package-json-lint-config/