### PR TITLE
Update `hr` styling to be less specific, and opt-in rather than opt-out

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -107,7 +107,7 @@ if ( $comments ) {
 if ( comments_open() || pings_open() ) {
 
 	if ( $comments ) {
-		echo '<hr class="is-style-wide" aria-hidden="true" />';
+		echo '<hr class="styled-separator is-style-wide" aria-hidden="true" />';
 	}
 
 	comment_form(
@@ -121,7 +121,7 @@ if ( comments_open() || pings_open() ) {
 } elseif ( is_single() ) {
 
 	if ( $comments ) {
-		echo '<hr class="is-style-wide" aria-hidden="true" />';
+		echo '<hr class="styled-separator is-style-wide" aria-hidden="true" />';
 	}
 
 	?>

--- a/functions.php
+++ b/functions.php
@@ -630,11 +630,11 @@ function twentytwenty_get_elements_array() {
 				'color' => array( 'cite', 'figcaption', '.wp-caption-text', '.post-meta', '.entry-content .wp-block-archives li', '.entry-content .wp-block-categories li', '.entry-content .wp-block-latest-posts li', '.wp-block-latest-comments__comment-date', '.wp-block-latest-posts__post-date', '.wp-block-embed figcaption', '.wp-block-image figcaption', '.wp-block-pullquote cite', '.comment-metadata', '.comment-respond .comment-notes', '.comment-respond .logged-in-as', '.pagination .dots' ),
 			),
 			'borders'    => array(
-				'border-color'        => array( 'pre', 'fieldset', 'input', 'textarea', 'table', 'table *' ),
+				'border-color'        => array( 'pre', 'fieldset', 'input', 'textarea', 'table', 'table *', 'hr' ),
 				'background'          => array( 'caption', 'code', 'code', 'kbd', 'samp' ),
 				'border-bottom-color' => array( '.wp-block-table.is-style-stripes' ),
 				'border-top-color'    => array( '.wp-block-latest-posts.is-grid li' ),
-				'color'               => array( 'hr:not(.is-style-dots):not(.reset-hr)' ),
+				'color'               => array( 'hr' ),
 			),
 		),
 		'header-footer' => array(

--- a/index.php
+++ b/index.php
@@ -73,7 +73,7 @@ get_header();
 		while ( have_posts() ) {
 			$i++;
 			if ( $i > 1 ) {
-				echo '<hr class="post-separator is-style-wide section-inner" aria-hidden="true" />';
+				echo '<hr class="post-separator styled-separator is-style-wide section-inner" aria-hidden="true" />';
 			}
 			the_post();
 

--- a/style.css
+++ b/style.css
@@ -509,7 +509,7 @@ address {
 
 hr {
 	border-style: solid;
-	border-width: .1rem 0 0 0;
+	border-width: 0.1rem 0 0 0;
 	border-color: #dcd7ca;
 	color: #dcd7ca;
 	margin: 4rem 0;

--- a/style.css
+++ b/style.css
@@ -508,21 +508,26 @@ address {
 }
 
 hr {
-	border-top: 0.1rem solid #dcd7ca;
+	border-style: solid;
+	border-width: .1rem 0 0 0;
+	border-color: #dcd7ca;
+	color: #dcd7ca;
 	margin: 4rem 0;
 }
 
-hr:not(.is-style-dots):not(.reset-hr) {
+.entry-content hr,
+hr.styled-separator {
 	background: linear-gradient(to left, currentColor calc(50% - 16px), transparent calc(50% - 16px), transparent calc(50% + 16px), currentColor calc(50% + 16px));
 	border: none;
-	color: #dcd7ca;
 	height: 0.1rem;
 	overflow: visible;
 	position: relative;
 }
 
-hr:not(.is-style-dots):not(.reset-hr)::before,
-hr:not(.is-style-dots):not(.reset-hr)::after {
+.entry-content hr::before,
+.entry-content hr::after,
+hr.styled-separator::before,
+hr.styled-separator::after {
 	background: currentColor;
 	content: "";
 	display: block;
@@ -533,11 +538,13 @@ hr:not(.is-style-dots):not(.reset-hr)::after {
 	width: 0.1rem;
 }
 
-hr::before {
+.entry-content hr::before,
+hr.styled-separator::before {
 	left: calc(50% - 0.5rem);
 }
 
-hr::after {
+.entry-content hr::after,
+hr.styled-separator::after {
 	right: calc(50% - 0.5rem);
 }
 
@@ -3157,11 +3164,20 @@ hr.wp-block-separator {
 /* STYLE: DOTS */
 
 .wp-block-separator.is-style-dots::before {
-	color: rgba(0, 0, 0, 0.42);
+	background: none;
+	color: inherit;
 	font-size: 3.2rem;
 	font-weight: 700;
+	height: auto;
 	letter-spacing: 1em;
 	padding-left: 1em;
+	position: static;
+	transform: none;
+	width: auto;
+}
+
+.wp-block-separator.is-style-dots::after {
+	content: none;
 }
 
 

--- a/template-parts/navigation.php
+++ b/template-parts/navigation.php
@@ -24,7 +24,7 @@ if ( $next_post || $prev_post ) {
 
 	<nav class="pagination-single section-inner<?php echo esc_attr( $pagination_classes ); ?>" aria-label="<?php esc_attr_e( 'Post', 'twentytwenty' ); ?>">
 
-		<hr class="is-style-wide" aria-hidden="true" />
+		<hr class="styled-separator is-style-wide" aria-hidden="true" />
 
 		<div class="pagination-single-inner">
 
@@ -53,7 +53,7 @@ if ( $next_post || $prev_post ) {
 
 		</div><!-- .pagination-single-inner -->
 
-		<hr class="is-style-wide" aria-hidden="true" />
+		<hr class="styled-separator is-style-wide" aria-hidden="true" />
 
 	</nav><!-- .pagination-single -->
 

--- a/template-parts/pagination.php
+++ b/template-parts/pagination.php
@@ -48,7 +48,7 @@ if ( $posts_pagination ) { ?>
 
 	<div class="pagination-wrapper section-inner">
 
-		<hr class="pagination-separator is-style-wide" aria-hidden="true" />
+		<hr class="styled-separator pagination-separator is-style-wide" aria-hidden="true" />
 
 		<?php echo $posts_pagination; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped during generation. ?>
 


### PR DESCRIPTION
Updates the hr styling to make the base `hr` element more generic, and adds the theme specific style to all `hr` elements in `.entry-content` and all `hr` elements with a specific class, making the styling opt-in rather than opt-out.

Created after a discussion in #529.