### PR TITLE
Fix uneven post spacing on archive

### DIFF
--- a/style.css
+++ b/style.css
@@ -2400,7 +2400,7 @@ body.template-cover .entry-header {
 	margin: 0;
 }
 
-body:not(.single) .post {
+body:not(.singular) main article:first-of-type {
 	padding: 4rem 0 0;
 }
 
@@ -4616,7 +4616,7 @@ a.to-the-top > * {
 		font-size: 3.2rem;
 	}
 
-	body:not(.single) .post {
+	body:not(.singular) main article:first-of-type {
 		padding: 8rem 0 0;
 	}
 


### PR DESCRIPTION
Updates the targeting to only hit the first article element, since the separator elements provide spacing between posts. Also updates the targeting to hit article elements that display pages or other non-post CPTs (in search results or on archive pages for custom post types).

Fixes #531.