### PR TITLE
Updates separator elements to use the secondary a11y color

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -627,14 +627,13 @@ function twentytwenty_get_elements_array() {
 				'color' => array( 'body', '.entry-title a' ),
 			),
 			'secondary'  => array(
-				'color' => array( 'cite', 'figcaption', '.wp-caption-text', '.post-meta', '.entry-content .wp-block-archives li', '.entry-content .wp-block-categories li', '.entry-content .wp-block-latest-posts li', '.wp-block-latest-comments__comment-date', '.wp-block-latest-posts__post-date', '.wp-block-embed figcaption', '.wp-block-image figcaption', '.wp-block-pullquote cite', '.comment-metadata', '.comment-respond .comment-notes', '.comment-respond .logged-in-as', '.pagination .dots' ),
+				'color' => array( 'cite', 'figcaption', '.wp-caption-text', '.post-meta', '.entry-content .wp-block-archives li', '.entry-content .wp-block-categories li', '.entry-content .wp-block-latest-posts li', '.wp-block-latest-comments__comment-date', '.wp-block-latest-posts__post-date', '.wp-block-embed figcaption', '.wp-block-image figcaption', '.wp-block-pullquote cite', '.comment-metadata', '.comment-respond .comment-notes', '.comment-respond .logged-in-as', '.pagination .dots', '.entry-content hr', 'hr.styled-separator' ),
 			),
 			'borders'    => array(
 				'border-color'        => array( 'pre', 'fieldset', 'input', 'textarea', 'table', 'table *', 'hr' ),
 				'background'          => array( 'caption', 'code', 'code', 'kbd', 'samp' ),
 				'border-bottom-color' => array( '.wp-block-table.is-style-stripes' ),
 				'border-top-color'    => array( '.wp-block-latest-posts.is-grid li' ),
-				'color'               => array( 'hr' ),
 			),
 		),
 		'header-footer' => array(

--- a/style.css
+++ b/style.css
@@ -511,7 +511,6 @@ hr {
 	border-style: solid;
 	border-width: 0.1rem 0 0 0;
 	border-color: #dcd7ca;
-	color: #dcd7ca;
 	margin: 4rem 0;
 }
 
@@ -519,6 +518,7 @@ hr {
 hr.styled-separator {
 	background: linear-gradient(to left, currentColor calc(50% - 16px), transparent calc(50% - 16px), transparent calc(50% + 16px), currentColor calc(50% + 16px));
 	border: none;
+	color: #6d6d6d;
 	height: 0.1rem;
 	overflow: visible;
 	position: relative;


### PR DESCRIPTION
Updates styled separators and entry content separators to use the secondary color (defaults to `#6d6d6d`) instead of the border color.

Partial fix for #533.