### PR TITLE
Fix header toggle labels being cut off in IE11

### DIFF
--- a/header.php
+++ b/header.php
@@ -48,7 +48,9 @@
 
 						<button class="toggle search-toggle mobile-search-toggle" data-toggle-target=".search-modal" data-toggle-screen-lock="true" data-toggle-body-class="showing-search-modal" data-set-focus=".search-modal .search-field" aria-expanded="false">
 							<div class="toggle-inner">
-								<?php twentytwenty_the_theme_svg( 'search' ); ?>
+								<div class="toggle-icon">
+									<?php twentytwenty_the_theme_svg( 'search' ); ?>
+								</div>
 								<span class="toggle-text"><?php _e( 'Search', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></span>
 							</div>
 						</button><!-- .search-toggle -->
@@ -69,7 +71,9 @@
 
 					<button class="toggle nav-toggle mobile-nav-toggle" data-toggle-target=".menu-modal" data-toggle-screen-lock="true" data-toggle-body-class="showing-menu-modal" aria-expanded="false" data-set-focus=".close-nav-toggle">
 						<div class="toggle-inner">
-							<?php twentytwenty_the_theme_svg( 'ellipsis' ); ?>
+							<div class="toggle-icon">
+								<?php twentytwenty_the_theme_svg( 'ellipsis' ); ?>
+							</div>
 							<span class="toggle-text"><?php _e( 'Menu', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></span>
 						</div>
 					</button><!-- .nav-toggle -->
@@ -145,7 +149,9 @@
 							<button class="toggle nav-toggle" data-toggle-target=".menu-modal" data-toggle-screen-lock="true" data-toggle-body-class="showing-menu-modal" aria-expanded="false" data-set-focus=".close-nav-toggle">
 								<div class="toggle-inner">
 									<span class="toggle-text"><?php _e( 'Menu', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></span>
-									<?php twentytwenty_the_theme_svg( 'ellipsis' ); ?>
+									<div class="toggle-icon">
+										<?php twentytwenty_the_theme_svg( 'ellipsis' ); ?>
+									</div>
 								</div>
 							</button><!-- .nav-toggle -->
 

--- a/style.css
+++ b/style.css
@@ -2148,6 +2148,10 @@ button.sub-menu-toggle.active svg {
 	padding: 4rem 0;
 }
 
+.menu-bottom nav {
+	width: 100%;
+}
+
 .menu-copyright {
 	display: none;
 	font-size: 1.6rem;

--- a/style.css
+++ b/style.css
@@ -1709,6 +1709,7 @@ body:not(.enable-search-modal) .site-logo img {
 	align-items: center;
 	display: flex;
 	outline: none;
+	overflow: visible;
 	padding: 0 2rem;
 }
 
@@ -1725,6 +1726,10 @@ body:not(.enable-search-modal) .site-logo img {
 .toggle-inner {
 	height: 2.3rem;
 	position: relative;
+}
+
+.toggle-icon {
+	overflow: hidden;
 }
 
 .toggle-inner .toggle-text {
@@ -1755,8 +1760,10 @@ body:not(.enable-search-modal) .site-logo img {
 	top: 0;
 }
 
+.search-toggle .toggle-icon,
 .search-toggle svg {
 	height: 2.3rem;
+	max-width: 2.3rem;
 	width: 2.3rem;
 }
 
@@ -1775,8 +1782,9 @@ body:not(.enable-search-modal) .site-logo img {
 	width: 6.6rem;
 }
 
+.nav-toggle .toggle-icon,
 .nav-toggle svg {
-	height: 0.7rem;
+	height: 0.8rem;
 	width: 2.6rem;
 }
 

--- a/style.css
+++ b/style.css
@@ -4567,10 +4567,6 @@ a.to-the-top > * {
 		margin-right: 4rem;
 	}
 
-	.menu-bottom .social-menu {
-		justify-content: flex-end;
-	}
-
 	/* Modal Search Form ------------------------- */
 
 	.modal-search-form {
@@ -5321,6 +5317,10 @@ a.to-the-top > * {
 
 	.menu-bottom {
 		padding: 6rem 0;
+	}
+
+	.menu-bottom .social-menu {
+		justify-content: flex-start;
 	}
 
 	/* Sub Page ------------------------------ */


### PR DESCRIPTION
Fixes the header toggle labels being cut off in IE 11. The fix required the header toggles to be set to `overflow: visible`, which resulted in the button SVGs causing a flex overflow issue on the body. That was fixed by wrapping the icons in new `.toggle-icon` elements with `overflow: hidden`.

Also fixes the modal social menu not wrapping correctly in IE, and updates the modal social menu to be aligned to the left on desktop (in all browsers), to match the design.

Fixes #348. #349 seems to be an unrelated issue.