### PR TITLE
Made content full width when using Full Width template

### DIFF
--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2356,6 +2356,10 @@ body.template-cover .entry-header {
 /*	7c. Template: Full Width
 /* -------------------------------------------------------------------------- */
 
+body.template-full-width .entry-content,
+body.template-full-width .entry-content p {
+	max-width: none;
+}
 
 /* -------------------------------------------------------------------------- */
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2362,11 +2362,11 @@ body.template-full-width .entry-content p {
 }
 
 body.template-full-width .entry-content .alignleft {
-    margin-left: 0;
+	margin-left: 0;
 }
 
 body.template-full-width .entry-content .alignright {
-    margin-right: 0;
+	margin-right: 0;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2361,6 +2361,14 @@ body.template-full-width .entry-content p {
 	max-width: none;
 }
 
+body.template-full-width .entry-content .alignleft {
+    margin-left: 0;
+}
+
+body.template-full-width .entry-content .alignright {
+    margin-right: 0;
+}
+
 /* -------------------------------------------------------------------------- */
 
 /*	8. Post: Archive

--- a/style.css
+++ b/style.css
@@ -2399,6 +2399,14 @@ body.template-full-width .entry-content p {
 	max-width: none;
 }
 
+body.template-full-width .entry-content .alignleft {
+    margin-left: 0;
+}
+
+body.template-full-width .entry-content .alignright {
+    margin-right: 0;
+}
+
 /* -------------------------------------------------------------------------- */
 
 /*	8. Post: Archive

--- a/style.css
+++ b/style.css
@@ -2400,11 +2400,11 @@ body.template-full-width .entry-content p {
 }
 
 body.template-full-width .entry-content .alignleft {
-    margin-left: 0;
+	margin-left: 0;
 }
 
 body.template-full-width .entry-content .alignright {
-    margin-right: 0;
+	margin-right: 0;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/style.css
+++ b/style.css
@@ -2394,6 +2394,10 @@ body.template-cover .entry-header {
 /*	7c. Template: Full Width
 /* -------------------------------------------------------------------------- */
 
+body.template-full-width .entry-content,
+body.template-full-width .entry-content p {
+	max-width: none;
+}
 
 /* -------------------------------------------------------------------------- */
 

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -25,7 +25,7 @@
 
 	?>
 
-	<div class="post-inner section-inner thin">
+	<div class="post-inner section-inner <?php echo is_page_template( 'templates/template-full-width.php' ) ? '' : 'thin'; ?> ">
 
 		<div class="entry-content">
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/twentytwenty/issues/185

Took at a stab at it. I assume any changes in `style.css` should be reflected in `style-rtl.css` as well?