### PR TITLE
Dropdown category widget exceeds parent div

### DIFF
--- a/style.css
+++ b/style.css
@@ -3931,6 +3931,10 @@ div.comment:first-of-type {
 	margin-top: 0.2rem;
 }
 
+.widget select {
+    max-width: 100%;
+}
+
 /* Font Families ----------------------------- */
 
 .widget_text p,

--- a/style.css
+++ b/style.css
@@ -3955,7 +3955,7 @@ div.comment:first-of-type {
 }
 
 .widget select {
-    max-width: 100%;
+	max-width: 100%;
 }
 
 /* Font Families ----------------------------- */


### PR DESCRIPTION
Drop-down category widget exceeds parent div on Twenty Twenty Theme.
[Before patch - exceeds parent div](https://prnt.sc/pb7uo7)
[After patch](https://prnt.sc/pb7v32)