### PR TITLE
Swap widget area names to `sidebar-1` and `sidebar-2`

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -89,24 +89,24 @@
 				<?php } ?>
 
 
-				<?php if ( is_active_sidebar( 'footer-one' ) || is_active_sidebar( 'footer-two' ) ) { ?>
+				<?php if ( is_active_sidebar( 'sidebar-1' ) || is_active_sidebar( 'sidebar-2' ) ) { ?>
 
 					<div class="footer-widgets-outer-wrapper">
 
 						<div class="footer-widgets-wrapper">
 
-							<?php if ( is_active_sidebar( 'footer-one' ) ) { ?>
+							<?php if ( is_active_sidebar( 'sidebar-1' ) ) { ?>
 
 								<div class="footer-widgets column-one grid-item">
-									<?php dynamic_sidebar( 'footer-one' ); ?>
+									<?php dynamic_sidebar( 'sidebar-1' ); ?>
 								</div>
 
 							<?php } ?>
 
-							<?php if ( is_active_sidebar( 'footer-two' ) ) { ?>
+							<?php if ( is_active_sidebar( 'sidebar-2' ) ) { ?>
 
 								<div class="footer-widgets column-two grid-item">
-									<?php dynamic_sidebar( 'footer-two' ); ?>
+									<?php dynamic_sidebar( 'sidebar-2' ); ?>
 								</div>
 
 							<?php } ?>

--- a/functions.php
+++ b/functions.php
@@ -123,7 +123,7 @@ function twentytwenty_theme_support() {
 
 	// Adds starter content to highlight the theme on fresh sites.
 	add_theme_support( 'starter-content', twentytwenty_get_starter_content() );
-	
+
 	// Add theme support for selective refresh for widgets.
 	add_theme_support( 'customize-selective-refresh-widgets' );
 
@@ -316,7 +316,7 @@ function twentytwenty_sidebar_registration() {
 			$shared_args,
 			array(
 				'name'        => __( 'Footer #1', 'twentytwenty' ),
-				'id'          => 'footer-one',
+				'id'          => 'sidebar-1',
 				'description' => __( 'Widgets in this area will be displayed in the first column in the footer.', 'twentytwenty' ),
 			)
 		)
@@ -328,7 +328,7 @@ function twentytwenty_sidebar_registration() {
 			$shared_args,
 			array(
 				'name'        => __( 'Footer #2', 'twentytwenty' ),
-				'id'          => 'footer-two',
+				'id'          => 'sidebar-2',
 				'description' => __( 'Widgets in this area will be displayed in the second column in the footer.', 'twentytwenty' ),
 			)
 		)

--- a/inc/starter-content.php
+++ b/inc/starter-content.php
@@ -23,11 +23,11 @@ function twentytwenty_get_starter_content() {
 	$starter_content = array(
 		'widgets'   => array(
 			// Place one core-defined widgets in the first tooter widget area.
-			'footer-one' => array(
+			'sidebar-1' => array(
 				'text_about',
 			),
 			// Place one core-defined widgets in the second tooter widget area.
-			'footer-two' => array(
+			'sidebar-2' => array(
 				'text_business_info',
 			),
 		),


### PR DESCRIPTION
This widget area ids from:

- `footer-one` -> `sidebar-1`
- `footer-two` -> `sidebar-2`

The labels remain the same as before.

These IDs are in line with other core themes and appear to be the most common configuration used by non-core themes as well.

Will close: #481 