### PR TITLE
Fix animated menus.

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -357,17 +357,20 @@ twentytwenty.modalMenu = {
 	},
 
 	expandLevel: function() {
-		var modalMenu = document.querySelector( '.modal-menu' );
-		var activeMenuItem = modalMenu.querySelector( '.current-menu-item' );
+		var modalMenus = document.querySelectorAll( '.modal-menu' );
 
-		if ( activeMenuItem ) {
-			twentytwentyFindParents( activeMenuItem, 'li' ).forEach( function( element ) {
-				var subMenuToggle = element.querySelector( '.sub-menu-toggle' );
-				if ( subMenuToggle ) {
-					subMenuToggle.click();
-				}
-			} );
-		}
+		modalMenus.forEach( function( modalMenu ) {
+			var activeMenuItem = modalMenu.querySelector( '.current-menu-item' );
+
+			if ( activeMenuItem ) {
+				twentytwentyFindParents( activeMenuItem, 'li' ).forEach( function( element ) {
+					var subMenuToggle = element.querySelector( '.sub-menu-toggle' );
+					if ( subMenuToggle ) {
+						twentytwenty.toggles.performToggle( subMenuToggle, true );
+					}
+				} );
+			}
+		} );
 	}
 }; // twentytwenty.modalMenu
 
@@ -388,98 +391,104 @@ twentytwenty.toggles = {
 		this.untoggleOnEscapeKeyPress();
 	},
 
+	performToggle: function( element, instantly ) {
+		var toggle, targetString, target, timeOutTime, classToToggle, activeClass;
+
+		// Get our targets
+		toggle = element;
+		targetString = toggle.dataset.toggleTarget;
+		activeClass = 'active';
+
+		if ( targetString === 'next' ) {
+			target = toggle.nextSibling;
+		} else {
+			target = document.querySelector( targetString );
+		}
+
+		// Trigger events on the toggle targets before they are toggled
+		if ( target.classList.contains( activeClass ) ) {
+			target.dispatchEvent( twentytwenty.createEvent( 'toggle-target-before-active' ) );
+		} else {
+			target.dispatchEvent( twentytwenty.createEvent( 'toggle-target-before-inactive' ) );
+		}
+
+		// Get the class to toggle, if specified
+		classToToggle = toggle.dataset.classToToggle ? toggle.dataset.classToToggle : activeClass;
+
+		// For cover modals, set a short timeout duration so the class animations have time to play out
+		timeOutTime = 0;
+
+		if ( target.classList.contains( 'cover-modal' ) ) {
+			timeOutTime = 10;
+		}
+
+		setTimeout( function() {
+			var focusElement, duration, newTarget, subMenued;
+
+			subMenued = target.classList.contains( 'sub-menu' );
+			newTarget = subMenued ? toggle.closest( '.menu-item' ).querySelector( '.sub-menu' ) : target;
+			duration = toggle.dataset.toggleDuration;
+
+			// Toggle the target of the clicked toggle
+			if ( toggle.dataset.toggleType === 'slidetoggle' && ! instantly && duration !== '0' ) {
+				twentytwentyMenuToggle( newTarget, duration );
+			} else {
+				newTarget.classList.toggle( classToToggle );
+			}
+
+			// If the toggle target is 'next', only give the clicked toggle the active class
+			if ( targetString === 'next' ) {
+				toggle.classList.toggle( activeClass );
+			} else if ( target.classList.contains( 'sub-menu' ) ) {
+				toggle.classList.toggle( activeClass );
+			} else {
+				// If not, toggle all toggles with this toggle target
+				document.querySelector( '*[data-toggle-target="' + targetString + '"]' ).classList.toggle( activeClass );
+			}
+
+			// Toggle aria-expanded on the target
+			twentytwentyToggleAttribute( target, 'aria-expanded', 'true', 'false' );
+
+			// Toggle aria-expanded on the toggle
+			twentytwentyToggleAttribute( toggle, 'aria-expanded', 'true', 'false' );
+
+			// Toggle body class
+			if ( toggle.dataset.toggleBodyClass ) {
+				document.querySelector( 'body' ).classList.toggle( toggle.dataset.toggleBodyClass );
+			}
+
+			// Check whether to set focus
+			if ( toggle.dataset.setFocus ) {
+				focusElement = document.querySelector( toggle.dataset.setFocus );
+
+				if ( focusElement ) {
+					if ( target.classList.contains( activeClass ) ) {
+						focusElement.focus();
+					} else {
+						focusElement.blur();
+					}
+				}
+			}
+
+			// Trigger the toggled event on the toggle target
+			target.dispatchEvent( twentytwenty.createEvent( 'toggled' ) );
+
+			// Trigger events on the toggle targets after they are toggled
+			if ( target.classList.contains( activeClass ) ) {
+				target.dispatchEvent( twentytwenty.createEvent( 'toggle-target-after-active' ) );
+			} else {
+				target.dispatchEvent( twentytwenty.createEvent( 'toggle-target-after-inactive' ) );
+			}
+		}, timeOutTime );
+	},
+
 	// Do the toggle
 	toggle: function() {
+		var self = this;
+
 		document.querySelectorAll( '*[data-toggle-target]' ).forEach( function( element ) {
 			element.addEventListener( 'click', function() {
-				var toggle, targetString, target, timeOutTime, classToToggle, activeClass;
-
-				// Get our targets
-				toggle = element;
-				targetString = toggle.dataset.toggleTarget;
-				activeClass = 'active';
-
-				if ( targetString === 'next' ) {
-					target = toggle.nextSibling;
-				} else {
-					target = document.querySelector( targetString );
-				}
-
-				// Trigger events on the toggle targets before they are toggled
-				if ( target.classList.contains( activeClass ) ) {
-					target.dispatchEvent( twentytwenty.createEvent( 'toggle-target-before-active' ) );
-				} else {
-					target.dispatchEvent( twentytwenty.createEvent( 'toggle-target-before-inactive' ) );
-				}
-
-				// Get the class to toggle, if specified
-				classToToggle = toggle.dataset.classToToggle ? toggle.dataset.classToToggle : activeClass;
-
-				// For cover modals, set a short timeout duration so the class animations have time to play out
-				timeOutTime = 0;
-
-				if ( target.classList.contains( 'cover-modal' ) ) {
-					timeOutTime = 10;
-				}
-
-				setTimeout( function() {
-					var focusElement, duration, newTarget, subMenued;
-
-					// Toggle the target of the clicked toggle
-					if ( toggle.dataset.toggleType === 'slidetoggle' ) {
-						duration = toggle.dataset.toggleDuration ? toggle.dataset.toggleDuration : 250;
-						subMenued = target.classList.contains( 'sub-menu' );
-						newTarget = subMenued ? toggle.closest( '.menu-item' ).querySelector( '.sub-menu' ) : target;
-
-						twentytwentySlideToggle( newTarget, duration );
-					} else {
-						target.classList.toggle( classToToggle );
-					}
-
-					// If the toggle target is 'next', only give the clicked toggle the active class
-					if ( targetString === 'next' ) {
-						toggle.classList.toggle( activeClass );
-					} else if ( target.classList.contains( 'sub-menu' ) ) {
-						toggle.classList.toggle( activeClass );
-					} else {
-						// If not, toggle all toggles with this toggle target
-						document.querySelector( '*[data-toggle-target="' + targetString + '"]' ).classList.toggle( activeClass );
-					}
-
-					// Toggle aria-expanded on the target
-					twentytwentyToggleAttribute( target, 'aria-expanded', 'true', 'false' );
-
-					// Toggle aria-expanded on the toggle
-					twentytwentyToggleAttribute( toggle, 'aria-expanded', 'true', 'false' );
-
-					// Toggle body class
-					if ( toggle.dataset.toggleBodyClass ) {
-						document.querySelector( 'body' ).classList.toggle( toggle.dataset.toggleBodyClass );
-					}
-
-					// Check whether to set focus
-					if ( toggle.dataset.setFocus ) {
-						focusElement = document.querySelector( toggle.dataset.setFocus );
-
-						if ( focusElement ) {
-							if ( target.classList.contains( activeClass ) ) {
-								focusElement.focus();
-							} else {
-								focusElement.blur();
-							}
-						}
-					}
-
-					// Trigger the toggled event on the toggle target
-					target.dispatchEvent( twentytwenty.createEvent( 'toggled' ) );
-
-					// Trigger events on the toggle targets after they are toggled
-					if ( target.classList.contains( activeClass ) ) {
-						target.dispatchEvent( twentytwenty.createEvent( 'toggle-target-after-active' ) );
-					} else {
-						target.dispatchEvent( twentytwenty.createEvent( 'toggle-target-after-inactive' ) );
-					}
-				}, timeOutTime );
+				self.performToggle( element );
 			} );
 		} );
 	},
@@ -581,96 +590,100 @@ function twentytwentyToggleAttribute( element, attribute, trueVal, falseVal ) {
 }
 
 /**
- * twentytwentySlideUp
- *
- * this implementation is coming from https://w3bits.com/javascript-slidetoggle/
+ * Toggle a menu item on or off.
  *
  * @param {HTMLElement} target
  * @param {number} duration
  */
-function twentytwentySlideUp( target, duration ) {
-	target.style.transitionProperty = 'height, margin, padding'; /* [1.1] */
-	target.style.transitionDuration = duration + 'ms'; /* [1.2] */
-	target.style.boxSizing = 'border-box'; /* [2] */
-	target.style.height = target.offsetHeight + 'px'; /* [3] */
-	target.style.height = 0; /* [4] */
-	target.style.paddingTop = 0; /* [5.1] */
-	target.style.paddingBottom = 0; /* [5.2] */
-	target.style.marginTop = 0; /* [6.1] */
-	target.style.marginBottom = 0; /* [7.2] */
-	target.style.overflow = 'hidden'; /* [7] */
-	window.setTimeout( function() {
-		target.style.display = 'none'; /* [8] */
-		target.style.removeProperty( 'height' ); /* [9] */
-		target.style.removeProperty( 'padding-top' ); /* [10.1] */
-		target.style.removeProperty( 'padding-bottom' ); /* [10.2] */
-		target.style.removeProperty( 'margin-top' ); /* [11.1] */
-		target.style.removeProperty( 'margin-bottom' ); /* [11.2] */
-		target.style.removeProperty( 'overflow' ); /* [12] */
-		target.style.removeProperty( 'transition-duration' ); /* [13.1] */
-		target.style.removeProperty( 'transition-property' ); /* [13.2] */
-	}, duration );
-}
+function twentytwentyMenuToggle( target, duration ) {
+	var initialPositions = [];
+	var finalPositions = [];
+	var initialParentHeight, finalParentHeight;
+	var menu, menuItems;
+	var transitionListener;
 
-/**
- * twentytwentySlideDown
- *
- * this implementation is coming from https://w3bits.com/javascript-slidetoggle/
- *
- * @param {HTMLElement} target
- * @param {number} duration
- */
-function twentytwentySlideDown( target, duration ) {
-	var height, display;
-	target.style.removeProperty( 'display' ); /* [1] */
-	display = window.getComputedStyle( target ).display;
-	if ( display === 'none' ) { /* [2] */
-		display = 'block';
-	}
-	target.style.display = display;
-
-	height = target.offsetHeight; /* [3] */
-	target.style.height = 0; /* [4] */
-	target.style.paddingTop = 0; /* [5.1] */
-	target.style.paddingBottom = 0; /* [5.2] */
-	target.style.marginTop = 0; /* [6.1] */
-	target.style.marginBottom = 0; /* [6.2] */
-	target.style.overflow = 'hidden'; /* [7] */
-
-	target.style.boxSizing = 'border-box'; /* [8] */
-	target.style.transitionProperty = 'height, margin, padding'; /* [9.1] */
-	target.style.transitionDuration = duration + 'ms'; /* [9.2] */
-	target.style.height = height + 'px'; /* [10] */
-	target.style.removeProperty( 'padding-top' ); /* [11.1] */
-	target.style.removeProperty( 'padding-bottom' ); /* [11.2] */
-	target.style.removeProperty( 'margin-top' ); /* [12.1] */
-	target.style.removeProperty( 'margin-bottom' ); /* [12.2] */
-
-	window.setTimeout( function() {
-		target.style.removeProperty( 'height' ); /* [13] */
-		target.style.removeProperty( 'overflow' ); /* [14] */
-		target.style.removeProperty( 'transition-duration' ); /* [15.1] */
-		target.style.removeProperty( 'transition-property' ); /* [15.2] */
-	}, duration );
-}
-
-/**
- * twentytwentySlideToggle
- *
- * this implementation is coming from https://w3bits.com/javascript-slidetoggle/
- *
- * @param {HTMLElement} target
- * @param {number} duration
- */
-function twentytwentySlideToggle( target, duration ) {
-	if ( duration === undefined ) {
-		duration = 500;
+	if ( ! target ) {
+		return;
 	}
 
-	if ( window.getComputedStyle( target ).display === 'none' ) {
-		return twentytwentySlideDown( target, duration );
-	}
-	return twentytwentySlideUp( target, duration );
+	menu = target.closest( '.modal-menu' );
+
+	// Step 1: look at the initial positions of every menu item.
+	menuItems = menu.querySelectorAll( '.menu-item' );
+
+	menuItems.forEach( function( menuItem, index ) {
+		initialPositions[ index ] = menuItem.offsetTop;
+	} );
+	initialParentHeight = target.parentElement.offsetHeight;
+
+	target.classList.add( 'toggling-target' );
+
+	// Step 2: toggle target menu item and look at the final positions of every menu item.
+	target.classList.toggle( 'active' );
+
+	menuItems.forEach( function( menuItem, index ) {
+		finalPositions[ index ] = menuItem.offsetTop;
+	} );
+	finalParentHeight = target.parentElement.offsetHeight;
+
+	// Step 3: close target menu item again.
+	// The whole process happens without giving the browser a chance to render, so it's invisible.
+	target.classList.toggle( 'active' );
+
+	// Step 4: prepare animation.
+	// Position all the items with absolute offsets, at the same starting position.
+	// Shouldn't result in any visual changes if done right.
+	menu.classList.add( 'is-toggling' );
+	target.classList.toggle( 'active' );
+	menuItems.forEach( function( menuItem, index ) {
+		var initialPosition = initialPositions[ index ];
+		if ( initialPosition === 0 && menuItem.parentElement === target ) {
+			initialPosition = initialParentHeight;
+		}
+		menuItem.style.transform = 'translate(0, ' + initialPosition + 'px)';
+	} );
+
+	// The double rAF is unfortunately needed, since we're toggling CSS classes, and
+	// the only way to ensure layout completion here across browsers is to wait twice.
+	// This just delays the start of the animation by 2 frames and is thus not an issue.
+	requestAnimationFrame( function() {
+		requestAnimationFrame( function() {
+			// Step 5: start animation by moving everything to final position.
+			// All the layout work has already happened, while we were preparing for the animation.
+			// The animation now runs entirely in CSS, using cheap CSS properties (opacity and transform)
+			// that don't trigger the layout or paint stages.
+			menu.classList.add( 'is-animating' );
+			menuItems.forEach( function( menuItem, index ) {
+				var finalPosition = finalPositions[ index ];
+				if ( finalPosition === 0 && menuItem.parentElement === target ) {
+					finalPosition = finalParentHeight;
+				}
+				if ( duration !== undefined ) {
+					menuItem.style.transitionDuration = duration + 'ms';
+				}
+				menuItem.style.transform = 'translate(0, ' + finalPosition + 'px)';
+			} );
+			if ( duration !== undefined ) {
+				target.style.transitionDuration = duration + 'ms';
+			}
+		} );
+
+		// Step 6: finish toggling.
+		// Remove all transient classes when the animation ends.
+		transitionListener = function() {
+			menu.classList.remove( 'is-animating' );
+			menu.classList.remove( 'is-toggling' );
+			target.classList.remove( 'toggling-target' );
+			menuItems.forEach( function( menuItem ) {
+				menuItem.style.transform = '';
+				menuItem.style.transitionDuration = '';
+			} );
+			target.style.transitionDuration = '';
+			target.removeEventListener( 'transitionend', transitionListener );
+		};
+
+		target.addEventListener( 'transitionend', transitionListener );
+	} );
 }
 
 /**

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -606,13 +606,13 @@ function twentytwentyMenuToggle( target, duration ) {
 		return;
 	}
 
-	menu = target.closest( '.modal-menu' );
+	menu = target.closest( '.menu-wrapper' );
 
 	// Step 1: look at the initial positions of every menu item.
 	menuItems = menu.querySelectorAll( '.menu-item' );
 
 	menuItems.forEach( function( menuItem, index ) {
-		initialPositions[ index ] = menuItem.offsetTop;
+		initialPositions[ index ] = { x: menuItem.offsetLeft, y: menuItem.offsetTop };
 	} );
 	initialParentHeight = target.parentElement.offsetHeight;
 
@@ -622,7 +622,7 @@ function twentytwentyMenuToggle( target, duration ) {
 	target.classList.toggle( 'active' );
 
 	menuItems.forEach( function( menuItem, index ) {
-		finalPositions[ index ] = menuItem.offsetTop;
+		finalPositions[ index ] = { x: menuItem.offsetLeft, y: menuItem.offsetTop };
 	} );
 	finalParentHeight = target.parentElement.offsetHeight;
 
@@ -637,10 +637,10 @@ function twentytwentyMenuToggle( target, duration ) {
 	target.classList.toggle( 'active' );
 	menuItems.forEach( function( menuItem, index ) {
 		var initialPosition = initialPositions[ index ];
-		if ( initialPosition === 0 && menuItem.parentElement === target ) {
-			initialPosition = initialParentHeight;
+		if ( initialPosition.y === 0 && menuItem.parentElement === target ) {
+			initialPosition.y = initialParentHeight;
 		}
-		menuItem.style.transform = 'translate(0, ' + initialPosition + 'px)';
+		menuItem.style.transform = 'translate(' + initialPosition.x + 'px, ' + initialPosition.y + 'px)';
 	} );
 
 	// The double rAF is unfortunately needed, since we're toggling CSS classes, and
@@ -655,13 +655,13 @@ function twentytwentyMenuToggle( target, duration ) {
 			menu.classList.add( 'is-animating' );
 			menuItems.forEach( function( menuItem, index ) {
 				var finalPosition = finalPositions[ index ];
-				if ( finalPosition === 0 && menuItem.parentElement === target ) {
-					finalPosition = finalParentHeight;
+				if ( finalPosition.y === 0 && menuItem.parentElement === target ) {
+					finalPosition.y = finalParentHeight;
 				}
 				if ( duration !== undefined ) {
 					menuItem.style.transitionDuration = duration + 'ms';
 				}
-				menuItem.style.transform = 'translate(0, ' + finalPosition + 'px)';
+				menuItem.style.transform = 'translate(' + finalPosition.x + 'px, ' + finalPosition.y + 'px)';
 			} );
 			if ( duration !== undefined ) {
 				target.style.transitionDuration = duration + 'ms';

--- a/style.css
+++ b/style.css
@@ -2134,6 +2134,72 @@ button.sub-menu-toggle.active svg {
 	font-weight: 500;
 }
 
+/* Main menu animation ----------------------- */
+
+.modal-menu .menu-item {
+	position: relative;
+}
+
+.modal-menu .active {
+	display: block;
+}
+
+.modal-menu.is-toggling {
+	pointer-events: none;
+}
+
+.modal-menu.is-toggling .menu-item {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+}
+
+.modal-menu.is-animating .menu-item,
+.modal-menu.is-animating .toggling-target {
+	transition-duration: 250ms;
+}
+
+.modal-menu.is-animating .menu-item {
+	transition-property: transform;
+}
+
+.modal-menu.is-toggling .toggling-target {
+	display: block;
+	position: absolute;
+	top: 0;
+	left: 0;
+	opacity: 1;
+}
+
+.modal-menu.is-toggling .toggling-target.active {
+	opacity: 0;
+}
+
+.modal-menu.is-animating.is-toggling .toggling-target {
+	display: block;
+	transition-property: opacity;
+	opacity: 0;
+}
+
+.modal-menu.is-animating.is-toggling .toggling-target.active {
+	opacity: 1;
+}
+
+.modal-menu.is-toggling > li:last-child li {
+	border-top-color: transparent;
+	border-bottom-width: 0.1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+	.modal-menu.is-animating .menu-item,
+	.modal-menu.is-animating .toggling-target {
+		transition-duration: 1ms !important;
+	}
+
+}
+
 
 /* Expanded Menu ----------------------------- */
 

--- a/style.css
+++ b/style.css
@@ -2136,35 +2136,40 @@ button.sub-menu-toggle.active svg {
 
 /* Main menu animation ----------------------- */
 
-.modal-menu .menu-item {
+.menu-wrapper .menu-item {
 	position: relative;
 }
 
-.modal-menu .active {
+.menu-wrapper .active {
 	display: block;
 }
 
-.modal-menu.is-toggling {
+.menu-wrapper.is-toggling {
 	pointer-events: none;
 }
 
-.modal-menu.is-toggling .menu-item {
+.menu-wrapper.is-toggling .menu-item {
 	position: absolute;
 	top: 0;
 	left: 0;
+	margin: 0;
 	width: 100%;
 }
 
-.modal-menu.is-animating .menu-item,
-.modal-menu.is-animating .toggling-target {
+.menu-wrapper.is-toggling .menu-bottom .social-menu .menu-item {
+	width: auto;
+}
+
+.menu-wrapper.is-animating .menu-item,
+.menu-wrapper.is-animating .toggling-target {
 	transition-duration: 250ms;
 }
 
-.modal-menu.is-animating .menu-item {
+.menu-wrapper.is-animating .menu-item {
 	transition-property: transform;
 }
 
-.modal-menu.is-toggling .toggling-target {
+.menu-wrapper.is-toggling .toggling-target {
 	display: block;
 	position: absolute;
 	top: 0;
@@ -2172,29 +2177,29 @@ button.sub-menu-toggle.active svg {
 	opacity: 1;
 }
 
-.modal-menu.is-toggling .toggling-target.active {
+.menu-wrapper.is-toggling .toggling-target.active {
 	opacity: 0;
 }
 
-.modal-menu.is-animating.is-toggling .toggling-target {
+.menu-wrapper.is-animating.is-toggling .toggling-target {
 	display: block;
 	transition-property: opacity;
 	opacity: 0;
 }
 
-.modal-menu.is-animating.is-toggling .toggling-target.active {
+.menu-wrapper.is-animating.is-toggling .toggling-target.active {
 	opacity: 1;
 }
 
-.modal-menu.is-toggling > li:last-child li {
+.menu-wrapper.is-toggling .modal-menu > li:last-child li {
 	border-top-color: transparent;
 	border-bottom-width: 0.1rem;
 }
 
 @media (prefers-reduced-motion: reduce) {
 
-	.modal-menu.is-animating .menu-item,
-	.modal-menu.is-animating .toggling-target {
+	.menu-wrapper.is-animating .menu-item,
+	.menu-wrapper.is-animating .toggling-target {
 		transition-duration: 1ms !important;
 	}
 

--- a/style.css
+++ b/style.css
@@ -2027,6 +2027,7 @@ ul.primary-menu {
 	display: flex;
 	justify-content: stretch;
 	overflow: auto;
+	-ms-overflow-style: auto;
 	width: 100%;
 }
 
@@ -2050,6 +2051,10 @@ button.close-nav-toggle {
 button.close-nav-toggle svg {
 	height: 2rem;
 	width: 2rem;
+}
+
+.menu-modal .menu-top {
+	flex-shrink: 0;
 }
 
 


### PR DESCRIPTION
The previous implementation didn't work, and even if it did, it would have performance issues due to animating layout-invalidating properties like `height`.

This rewrite animates the menu using only opacity and transform, leading to smooth animations in most devices. The animation is JS-orchestrated, but entirely CSS-driven. The animation is skipped if a user has configured their OS or browser to reduce animations.

Note that the implementation is complex, but this is required complexity for smooth, cross-browser animations in a sliding menu scenario. When reviewing, **please consider whether this complexity is desirable, or whether it would be preferable to drop animations instead**.

This change also fixes issues with automatically opening sub-menus on page load.

Summary of changes:
- Rewrite menu animation functionality.
- Extract toggling function out of `click` event hander, so it can be used without triggering click events.
- Ensure that the initial menu opening is done on all menus, not just the first one (there are two menus; one for desktop and one for mobile).

Fixes #513. Tested and working in recent Chrome, recent Firefox, recent Safari, and IE11.