### PR TITLE
Add `:focus` pseudo-class selector to `:hover` selectors

### DIFF
--- a/assets/css/editor-style-classic.css
+++ b/assets/css/editor-style-classic.css
@@ -206,6 +206,7 @@ body#tinymce.wp-editor pre {
 }
 
 body#tinymce.wp-editor a,
+body#tinymce.wp-editor a:focus,
 body#tinymce.wp-editor a:hover {
 	color: #cd2653;
 	text-decoration: underline;
@@ -658,6 +659,7 @@ body#tinymce.wp-editor input[type="submit"]:focus {
 /* BUTTON STYLE: OUTLINE */
 
 body#tinymce.wp-editor .is-style-outline .wp-block-button__link,
+body#tinymce.wp-editor .is-style-outline .wp-block-button__link:focus,
 body#tinymce.wp-editor .is-style-outline .wp-block-button__link:hover {
 	color: #cd2653;
 }

--- a/functions.php
+++ b/functions.php
@@ -631,10 +631,10 @@ function twentytwenty_get_elements_array() {
 	$elements = array(
 		'content'       => array(
 			'accent'     => array(
-				'color'            => array( '.color-accent', '.color-accent-hover:hover', '.has-accent-color', '.has-drop-cap:not(:focus):first-letter', '.wp-block-button.is-style-outline', 'a' ),
-				'border-color'     => array( 'blockquote', '.border-color-accent', '.border-color-accent-hover:hover' ),
+				'color'            => array( '.color-accent', '.color-accent-hover:hover', '.color-accent-hover:focus', '.has-accent-color', '.has-drop-cap:not(:focus):first-letter', '.wp-block-button.is-style-outline', 'a' ),
+				'border-color'     => array( 'blockquote', '.border-color-accent', '.border-color-accent-hover:hover', '.border-color-accent-hover:focus' ),
 				'background'       => array( 'button:not(.toggle)', '.button', '.faux-button', '.wp-block-button__link', '.wp-block-file__button', 'input[type="button"]', 'input[type="reset"]', 'input[type="submit"]' ),
-				'background-color' => array( '.bg-accent', '.bg-accent-hover:hover', '.has-accent-background-color', '.comment-reply-link', '.edit-comment-link' ),
+				'background-color' => array( '.bg-accent', '.bg-accent-hover:hover', '.bg-accent-hover:focus', '.has-accent-background-color', '.comment-reply-link', '.edit-comment-link' ),
 				'fill'             => array( '.fill-children-accent', '.fill-children-accent *' ),
 			),
 			'background' => array(

--- a/style.css
+++ b/style.css
@@ -903,22 +903,22 @@ input[type="submit"] {
 	transition: opacity 0.15s linear;
 }
 
-button:hover,
-.button:hover,
-.faux-button:hover,
-.wp-block-button__link:hover,
-.wp-block-file .wp-block-file__button:hover,
-input[type="button"]:hover,
-input[type="reset"]:hover,
-input[type="submit"]:hover,
 button:focus,
+button:hover,
 .button:focus,
+.button:hover,
 .faux-button:focus,
+.faux-button:hover,
 .wp-block-button__link:focus,
+.wp-block-button__link:hover,
 .wp-block-file .wp-block-file__button:focus,
+.wp-block-file .wp-block-file__button:hover,
 input[type="button"]:focus,
+input[type="button"]:hover,
 input[type="reset"]:focus,
-input[type="submit"]:focus {
+input[type="reset"]:hover,
+input[type="submit"]:focus,
+input[type="submit"]:hover {
 	text-decoration: underline;
 }
 
@@ -1109,6 +1109,7 @@ button.toggle {
 /* COLOR */
 
 .color-accent,
+.color-accent-hover:focus,
 .color-accent-hover:hover {
 	color: #cd2653;
 }
@@ -1116,6 +1117,7 @@ button.toggle {
 /* BACKGROUND COLOR */
 
 .bg-accent,
+.bg-accent-hover:focus,
 .bg-accent-hover:hover {
 	background-color: #cd2653;
 }
@@ -1123,6 +1125,7 @@ button.toggle {
 /* BORDER COLOR */
 
 .border-color-accent,
+.border-color-accent-hover:focus,
 .border-color-accent-hover:hover {
 	border-color: #cd2653;
 }
@@ -1303,8 +1306,8 @@ ul.social-icons li {
 	width: 4.4rem;
 }
 
-.social-icons a:hover,
-.social-icons a:focus {
+.social-icons a:focus,
+.social-icons a:hover {
 	transform: scale(1.1);
 	text-decoration: none;
 }
@@ -1631,8 +1634,8 @@ body:not(.enable-search-modal) .header-titles-wrapper {
 	text-decoration: none;
 }
 
-.site-title a:hover,
-.site-title a:focus {
+.site-title a:focus,
+.site-title a:hover {
 	outline: none;
 	text-decoration: underline;
 }
@@ -1746,8 +1749,8 @@ body:not(.enable-search-modal) .site-logo img {
 	color: inherit;
 }
 
-.header-inner .toggle:hover .toggle-text,
-.header-inner .toggle:focus .toggle-text {
+.header-inner .toggle:focus .toggle-text,
+.header-inner .toggle:hover .toggle-text {
 	text-decoration: underline;
 }
 
@@ -1868,8 +1871,8 @@ ul.primary-menu {
 	text-decoration: none;
 }
 
-.primary-menu a:hover,
-.primary-menu a:focus {
+.primary-menu a:focus,
+.primary-menu a:hover {
 	outline: none;
 	text-decoration: underline;
 }
@@ -2092,6 +2095,7 @@ button.close-nav-toggle svg {
 	width: 100%;
 }
 
+.modal-menu a:focus,
 .modal-menu a:hover,
 .modal-menu li.current-menu-item > .ancestor-wrapper > a {
 	text-decoration: underline;
@@ -2159,6 +2163,7 @@ button.sub-menu-toggle.active svg {
 	margin: 0;
 }
 
+.menu-copyright a:focus,
 .menu-copyright a:hover {
 	text-decoration: underline;
 }
@@ -2244,6 +2249,7 @@ button.search-untoggle {
 	width: 1.5rem;
 }
 
+.search-untoggle:focus svg,
 .search-untoggle:hover svg {
 	transform: scale(1.15);
 }
@@ -2384,6 +2390,7 @@ body.template-cover .entry-header {
 	width: 1.767rem;
 }
 
+.to-the-content:focus svg,
 .to-the-content:hover svg {
 	transform: translateY(20%);
 }
@@ -2465,6 +2472,7 @@ h2.entry-title {
 	text-decoration: none;
 }
 
+.entry-title a:focus,
 .entry-title a:hover {
 	text-decoration: underline;
 }
@@ -2511,6 +2519,7 @@ h2.entry-title {
 	text-decoration: none;
 }
 
+.post-meta a:focus,
 .post-meta a:hover {
 	text-decoration: underline;
 }
@@ -2683,6 +2692,7 @@ h2.entry-title {
 	text-decoration: none;
 }
 
+.author-bio .author-link:focus,
 .author-bio .author-link:hover {
 	text-decoration: underline;
 }
@@ -2724,6 +2734,7 @@ h2.entry-title {
 	margin-right: 1rem;
 }
 
+.pagination-single a:focus .title
 .pagination-single a:hover .title {
 	text-decoration: underline;
 }
@@ -2983,6 +2994,7 @@ h2.entry-title {
 	margin-right: 1rem;
 }
 
+.wp-block-file a:not(.wp-block-file__button):focus,
 .wp-block-file a:not(.wp-block-file__button):hover {
 	text-decoration: underline;
 }
@@ -3335,6 +3347,7 @@ hr.wp-block-separator {
 	margin-bottom: 0;
 }
 
+.entry-content a:focus,
 .entry-content a:hover {
 	text-decoration: underline;
 }
@@ -3553,6 +3566,7 @@ div.comment:first-of-type {
 	text-decoration: none;
 }
 
+.comment-metadata a:focus,
 .comment-metadata a:hover {
 	text-decoration: underline;
 }
@@ -3655,6 +3669,7 @@ div.comment:first-of-type {
 	text-decoration: none;
 }
 
+.comment-footer-meta a:focus,
 .comment-footer-meta a:hover {
 	text-decoration: underline;
 }
@@ -3687,6 +3702,7 @@ div.comment:first-of-type {
 	text-decoration: none;
 }
 
+.comments-pagination .page-numbers:focus,
 .comments-pagination .page-numbers:hover {
 	text-decoration: underline;
 }
@@ -3729,7 +3745,9 @@ div.comment:first-of-type {
 	text-decoration: none;
 }
 
+.comment-respond .comment-notes a:focus,
 .comment-respond .comment-notes a:hover,
+.comment-respond .logged-in-as a:focus,
 .comment-respond .logged-in-as a:hover {
 	text-decoration: underline;
 }
@@ -3807,6 +3825,7 @@ div.comment:first-of-type {
 	text-decoration: none;
 }
 
+.comment-reply-title small a:focus,
 .comment-reply-title small a:hover {
 	text-decoration: underline;
 }
@@ -3845,6 +3864,7 @@ div.comment:first-of-type {
 	text-decoration: none;
 }
 
+.pagination a:focus,
 .pagination a:hover {
 	text-decoration: underline;
 }
@@ -4072,8 +4092,8 @@ div.comment:first-of-type {
 	text-decoration: none;
 }
 
-.widget_recent_comments a:hover,
-.widget_recent_comments a:focus {
+.widget_recent_comments a:focus,
+.widget_recent_comments a:hover {
 	text-decoration: underline;
 }
 
@@ -4232,6 +4252,7 @@ ul.footer-social li {
 	text-decoration: none;
 }
 
+.footer-bottom a:focus,
 .footer-bottom a:hover {
 	text-decoration: underline;
 }


### PR DESCRIPTION
Updates `:hover` selectors with a `:focus` pseudo-class selector

This is part of a pull request to follow adding the `a11y/selector-pseudo-class-focus` [stylelint-a11y rule](https://github.com/YozhikM/stylelint-a11y/tree/master/src/rules/selector-pseudo-class-focus) to check for accessibility issues

See https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html
