### PR TITLE
Remove left margin from gallery grid view

### DIFF
--- a/style.css
+++ b/style.css
@@ -2848,6 +2848,7 @@ h2.entry-title {
 
 .wp-block-archives,
 .wp-block-categories,
+.wp-block-gallery ul,
 .wp-block-latest-posts,
 .wp-block-latest-comments {
 	list-style: none;


### PR DESCRIPTION
Removes the left margin from gallery block grid views.

Fixes: #605 