### PR TITLE
Convert modal search to use `get_search_form()`

### DIFF
--- a/404.php
+++ b/404.php
@@ -21,7 +21,7 @@ get_header();
 		<?php
 		get_search_form(
 			array(
-				'label' => __( '404 not found', 'twentytwenty' ),
+				'label' => _x( '404 not found', 'Label', 'twentytwenty' ),
 			)
 		);
 		?>

--- a/index.php
+++ b/index.php
@@ -27,10 +27,10 @@ get_header();
 	if ( is_search() ) {
 		global $wp_query;
 
-		$archive_title = sprintf( 
-			'%1$s %2$s', 
-			'<span class="color-accent">' . __( 'Search:', 'twentytwenty' ) . '</span>', 
-			'&ldquo;' . get_search_query() . '&rdquo;' 
+		$archive_title = sprintf(
+			'%1$s %2$s',
+			'<span class="color-accent">' . __( 'Search:', 'twentytwenty' ) . '</span>',
+			'&ldquo;' . get_search_query() . '&rdquo;'
 		);
 
 		if ( $wp_query->found_posts ) {
@@ -65,7 +65,7 @@ get_header();
 
 		<?php
 	}
-	
+
 	if ( have_posts() ) {
 
 		$i = 0;
@@ -88,7 +88,7 @@ get_header();
 			<?php
 			get_search_form(
 				array(
-					'label' => __( 'search again', 'twentytwenty' ),
+					'label' => _x( 'search again', 'Label', 'twentytwenty' ),
 				)
 			);
 			?>

--- a/style.css
+++ b/style.css
@@ -2223,7 +2223,7 @@ button.search-untoggle {
 
 /* Modal Search Form ------------------------- */
 
-.modal-search-form {
+.modal-search-form form {
 	position: relative;
 	width: 100%;
 }

--- a/template-parts/modal-search.php
+++ b/template-parts/modal-search.php
@@ -12,17 +12,15 @@
 
 	<div class="search-modal-inner modal-inner">
 
-		<div class="section-inner">
+		<div class="section-inner modal-search-form">
 
-			<?php $unique_id = esc_attr( uniqid( 'search-form-' ) ); ?>
-
-			<form role="search" method="get" class="modal-search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
-				<label class="screen-reader-text" for="<?php echo esc_attr( $unique_id ); ?>">
-					<?php echo _x( 'Search for:', 'Label', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- core trusts translations ?>
-				</label>
-				<input type="search" id="<?php echo esc_attr( $unique_id ); ?>" class="search-field" placeholder="<?php echo esc_attr_x( 'Search for&hellip;', 'Placeholder', 'twentytwenty' ); ?>" value="<?php echo get_search_query(); ?>" name="s" />
-				<button type="submit" class="search-submit"><?php echo _x( 'Search', 'Submit button', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- core trusts translations ?></button>
-			</form><!-- .search-form -->
+			<?php
+			get_search_form(
+				array(
+					'label' => _x( 'Search for:', 'Label', 'twentytwenty' ),
+				)
+			);
+			?>
 
 			<button class="toggle search-untoggle fill-children-current-color" data-toggle-target=".search-modal" data-toggle-screen-lock="true" data-toggle-body-class="showing-search-modal" data-set-focus=".search-modal .search-field">
 				<span class="screen-reader-text"><?php _e( 'Close search', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></span>


### PR DESCRIPTION
Converts the modal search to use the `get_serach_form()`.

Moves the `.modal-serach-form` class to the wrapper and changes the positioning rule to be ``.modal-serach-form form`.

On a quick test there seems to be no visual changes due to this. There is a small markup adjustment as a result but if that is a problem we can improve that in another PR. 

Closes: #219 