### PR TITLE
Guarantee a 1.36:1 contrast for borders color

### DIFF
--- a/assets/js/customize-controls.js
+++ b/assets/js/customize-controls.js
@@ -68,11 +68,10 @@
 			};
 
 			// Get borders color.
-			value[ context ].borders = Color( {
-				h: colors.bgColorObj.h(),
-				s: colors.bgColorObj.s() * 0.3922,
-				l: colors.isDark ? colors.bgColorObj.l() + 9 : colors.bgColorObj.l() - 9
-			} ).toCSS();
+			value[ context ].borders = colors.bgColorObj
+				.clone()
+				.getReadableContrastingColor( colors.bgColorObj, 1.36 )
+				.toCSS();
 
 			// Get secondary color.
 			value[ context ].secondary = Color( {


### PR DESCRIPTION
This PR changes the way border colors get calculated to guarantee a `1.36:1` contrast with the background.
See https://github.com/WordPress/twentytwenty/issues/533#issuecomment-535991705 for details