### PR TITLE
Search modal form style adjustments

### DIFF
--- a/style.css
+++ b/style.css
@@ -4578,11 +4578,11 @@ a.to-the-top > * {
 	.search-modal .search-field {
 		border: none;
 		font-size: 3.2rem;
-		height: 18.3rem;
+		height: 14rem;
 	}
 
 	.search-modal .search-field::-moz-placeholder {
-		line-height: 5.7;
+		line-height: 4.375;
 	}
 
 	/* Sub Page ------------------------------ */

--- a/style.css
+++ b/style.css
@@ -2223,12 +2223,12 @@ button.search-untoggle {
 
 /* Modal Search Form ------------------------- */
 
-.modal-search-form form {
+.search-modal form {
 	position: relative;
 	width: 100%;
 }
 
-.modal-search-form .search-field {
+.search-modal .search-field {
 	background: none;
 	border: none;
 	border-radius: 0;
@@ -2240,27 +2240,27 @@ button.search-untoggle {
 	width: 100%;
 }
 
-.modal-search-form .search-field::-webkit-input-placeholder {
+.search-modal .search-field::-webkit-input-placeholder {
 	color: inherit;
 }
 
-.modal-search-form .search-field:-ms-input-placeholder {
+.search-modal .search-field:-ms-input-placeholder {
 	color: inherit;
 }
 
-.modal-search-form .search-field::-moz-placeholder {
+.search-modal .search-field::-moz-placeholder {
 	color: inherit;
 	line-height: 4;
 }
 
-.modal-search-form .search-submit {
+.search-modal .search-submit {
 	position: absolute;
 	right: -9999rem;
 	top: 50%;
 	transform: translateY(-50%);
 }
 
-.modal-search-form .search-submit:focus {
+.search-modal .search-submit:focus {
 	right: 0;
 }
 
@@ -4565,7 +4565,7 @@ a.to-the-top > * {
 
 	/* Modal Search Form ------------------------- */
 
-	.modal-search-form {
+	.search-modal form {
 		position: relative;
 		width: 100%;
 	}
@@ -4575,13 +4575,13 @@ a.to-the-top > * {
 		width: 2.5rem;
 	}
 
-	.modal-search-form .search-field {
+	.search-modal .search-field {
 		border: none;
 		font-size: 3.2rem;
 		height: 18.3rem;
 	}
 
-	.modal-search-form .search-field::-moz-placeholder {
+	.search-modal .search-field::-moz-placeholder {
 		line-height: 5.7;
 	}
 

--- a/template-parts/modal-search.php
+++ b/template-parts/modal-search.php
@@ -12,7 +12,7 @@
 
 	<div class="search-modal-inner modal-inner">
 
-		<div class="section-inner modal-search-form">
+		<div class="section-inner">
 
 			<?php
 			get_search_form(


### PR DESCRIPTION
Fixes an issue where the search modal form doesn't have any left/right margins on tablets (as in the search field text goes to the edge of the screen). 

Also reduces the height of the search form to make it less dominant, which fixes #599.