### PR TITLE
Adjust spacing on archive pages

### DIFF
--- a/style.css
+++ b/style.css
@@ -2422,6 +2422,13 @@ body.template-full-width .entry-content .alignright {
 	margin: 0;
 }
 
+.archive-subtitle p:last-child {
+	margin-bottom: 0;
+}
+
+
+/* Posts ------------------------------------- */
+
 body:not(.singular) main article:first-of-type {
 	padding: 4rem 0 0;
 }

--- a/style.css
+++ b/style.css
@@ -2427,6 +2427,13 @@ body:not(.singular) main article:first-of-type {
 }
 
 
+/* Search Results ---------------------------- */
+
+.no-search-results-form {
+	padding-top: 5rem;
+}
+
+
 /* -------------------------------------------------------------------------- */
 
 /*	9. Post: Single
@@ -4679,6 +4686,12 @@ a.to-the-top > * {
 
 	h2.entry-title {
 		font-size: 6.4rem;
+	}
+
+	/* SEARCH RESULTS */
+
+	.no-search-results-form {
+		padding-top: 8rem;
 	}
 
 	/* Post: Single -------------------------- */


### PR DESCRIPTION
Adds a top padding to the no search results form. Fixes #611. 

Also removes the bottom margin of the last paragraph in the `.archive-subtitle` element, since it was adding additional bottom spacing to the `.archive-header`.