### PR TITLE
Better handling of long site titles

### DIFF
--- a/style.css
+++ b/style.css
@@ -5195,6 +5195,7 @@ a.to-the-top > * {
 
 	.header-titles-wrapper {
 		margin-right: 4rem;
+		max-width: 50%;
 		padding: 0;
 		text-align: left;
 	}
@@ -5211,11 +5212,6 @@ a.to-the-top > * {
 	.header-titles .site-logo,
 	.header-titles .site-description {
 		margin: 1rem 0 0 2.4rem;
-	}
-
-	.header-titles .site-title,
-	.header-titles .site-logo {
-		flex-shrink: 0;
 	}
 
 	.wp-custom-logo .header-titles {


### PR DESCRIPTION
Improves the handling of long site titles by allowing the site title to wrap. Also sets a `max-width: 50%;` on the `.header-titles-wrapper` above 1000px, to guarantee a minimum amount of space for the navigation elements in the header.

Fixes #603.