### PR TITLE
Reduce spacing when the same background color is set

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -664,7 +664,7 @@ function twentytwenty_get_elements_array() {
 				'color' => array( '.site-description', 'body:not(.overlay-header) .toggle-inner .toggle-text', '.widget .post-date', '.widget .rss-date', '.widget_archive li', '.widget_categories li', '.widget cite', '.widget_pages li', '.widget_meta li', '.widget_nav_menu li', '.powered-by-wordpress', '.to-the-top', '.singular .entry-header .post-meta', '.singular:not(.overlay-header) .entry-header .post-meta a' ),
 			),
 			'borders'    => array(
-				'border-color'        => array( '.header-footer-group pre', '.header-footer-group fieldset', '.header-footer-group input', '.header-footer-group textarea', '.header-footer-group table', '.header-footer-group table *', '.menu-modal nav *', '.footer-widgets-outer-wrapper', '.footer-top' ),
+				'border-color'        => array( '.header-footer-group pre', '.header-footer-group fieldset', '.header-footer-group input', '.header-footer-group textarea', '.header-footer-group table', '.header-footer-group table *', '.menu-modal nav *', '.reduced-spacing #site-footer', '.footer-widgets-outer-wrapper', '.footer-top' ),
 				'background'          => array( '.header-footer-group table caption', 'body:not(.overlay-header) .header-inner .toggle-wrapper::before' ),
 				'border-bottom-color' => array( '.wp-block-table.is-style-stripes' ),
 				'border-top-color'    => array( '.wp-block-latest-posts.is-grid li' ),

--- a/style.css
+++ b/style.css
@@ -4209,7 +4209,7 @@ div.comment:first-of-type {
 }
 
 .reduced-spacing #site-footer {
-	border-top: .1rem solid #dedfdf;
+	border-top: 0.1rem solid #dedfdf;
 }
 
 .footer-top,

--- a/style.css
+++ b/style.css
@@ -2640,6 +2640,10 @@ h2.entry-title {
 	padding-top: 5rem;
 }
 
+.reduced-spacing.missing-post-thumbnail .post-inner {
+	padding-top: 0;
+}
+
 
 /* Post Footer ------------------------------- */
 
@@ -4202,6 +4206,10 @@ div.comment:first-of-type {
 #site-footer {
 	background-color: #fff;
 	margin-top: 5rem;
+}
+
+.reduced-spacing #site-footer {
+	border-top: .1rem solid #dedfdf;
 }
 
 .footer-top,

--- a/style.css
+++ b/style.css
@@ -2422,8 +2422,22 @@ body.template-full-width .entry-content .alignright {
 	margin: 0;
 }
 
+.archive-subtitle p:last-child {
+	margin-bottom: 0;
+}
+
+
+/* Posts ------------------------------------- */
+
 body:not(.singular) main article:first-of-type {
 	padding: 4rem 0 0;
+}
+
+
+/* Search Results ---------------------------- */
+
+.no-search-results-form {
+	padding-top: 5rem;
 }
 
 
@@ -4679,6 +4693,12 @@ a.to-the-top > * {
 
 	h2.entry-title {
 		font-size: 6.4rem;
+	}
+
+	/* SEARCH RESULTS */
+
+	.no-search-results-form {
+		padding-top: 8rem;
 	}
 
 	/* Post: Single -------------------------- */

--- a/style.css
+++ b/style.css
@@ -2415,6 +2415,10 @@ body.template-full-width .entry-content .alignright {
 	padding: 4rem 0;
 }
 
+.reduced-spacing .archive-header {
+	padding-bottom: 2rem;
+}
+
 .archive-title {
 	font-size: 2.4rem;
 	font-weight: 700;
@@ -4689,6 +4693,10 @@ a.to-the-top > * {
 
 	.archive-header {
 		padding: 8rem 0;
+	}
+
+	.reduced-spacing .archive-header {
+		padding-bottom: 3rem;
 	}
 
 	.archive-title {


### PR DESCRIPTION
Adds styles to adjust the spacing between some elements when the "Background Color" and "Header & Footer Background Color" settings are set to the same colors, using the `.reduced-spacing` class added in #582.

Combined with updates to the alignment classes in previous PRs, fixes #501.

**Before:**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/8181091/65814859-dc3a1600-e1e7-11e9-98cf-576a653c7b26.png">

**After:**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/8181091/65814863-e4925100-e1e7-11e9-9a31-8ae629d5ace2.png">