### PR TITLE
Update the mobile menu to use the close button

### DIFF
--- a/style.css
+++ b/style.css
@@ -1499,7 +1499,6 @@ ul.social-icons li {
 #site-header {
 	background: #fff;
 	position: relative;
-	z-index: 9999;
 }
 
 .header-inner {
@@ -1901,7 +1900,6 @@ ul.primary-menu {
 	display: none;
 	opacity: 0;
 	overflow: auto;
-	padding: 8.4rem 0 0 0;
 	position: fixed;
 	bottom: 0;
 	left: -99999rem;
@@ -1951,17 +1949,21 @@ ul.primary-menu {
 
 button.close-nav-toggle {
 	align-items: center;
-	display: none;
-	font-size: 1.8rem;
+	display: flex;
+	font-size: 1.6rem;
 	font-weight: 500;
 	justify-content: flex-end;
-	padding: 4rem 0;
+	padding: 3.1rem 0;
 	width: 100%;
 }
 
 button.close-nav-toggle svg {
-	height: 2rem;
-	width: 2rem;
+	height: 1.6rem;
+	width: 1.6rem;
+}
+
+button.close-nav-toggle .toggle-text {
+	margin-right: 1.6rem;
 }
 
 .menu-modal .menu-top {
@@ -4570,8 +4572,18 @@ a.to-the-top > * {
 
 	/* Menu Modal ---------------------------- */
 
-	.menu-modal {
-		padding-top: 13.1rem;
+	button.close-nav-toggle {
+		font-size: 1.8rem;
+		padding: 4rem 0;
+	}
+
+	button.close-nav-toggle svg {
+		height: 2rem;
+		width: 2rem;
+	}
+
+	button.close-nav-toggle .toggle-text {
+		margin-right: 2.1rem;
 	}
 
 	.modal-menu {
@@ -5379,14 +5391,6 @@ a.to-the-top > * {
 
 	.expanded-menu {
 		display: block;
-	}
-
-	button.close-nav-toggle {
-		display: flex;
-	}
-
-	button.close-nav-toggle .toggle-text {
-		margin-right: 2.1rem;
 	}
 
 	.menu-bottom {


### PR DESCRIPTION
This PR updates the mobile menu to cover the entire screen, and use the close button which is also displayed on desktop. Fixes #625.

**Before and after:**
![mobile-menu-update](https://user-images.githubusercontent.com/8181091/65815655-caaa3b80-e1f2-11e9-97bf-03ddc655ef12.png)
