### PR TITLE
Fix widget margins for titles and list items

### DIFF
--- a/style.css
+++ b/style.css
@@ -3954,7 +3954,7 @@ div.comment:first-of-type {
 }
 
 .widget li {
-	margin-top: 2rem;
+	margin: 2rem 0 0 0;
 }
 
 .widget li:first-child,

--- a/style.css
+++ b/style.css
@@ -3949,7 +3949,7 @@ div.comment:first-of-type {
 	margin-bottom: 0;
 }
 
-.widget-title {
+.widget .widget-title {
 	margin: 0 0 2rem;
 }
 
@@ -5098,7 +5098,7 @@ a.to-the-top > * {
 
 	/* Widgets ------------------------------- */
 
-	.widget-title {
+	.widget .widget-title {
 		margin-bottom: 3rem;
 	}
 


### PR DESCRIPTION
Updates the targeting of widget titles to fix CSS not having any effect. Fixes #630.

Also adjusts the reset of the margin on the widget list items.