### PR TITLE
Fix cover template text color setting not applying to the header

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -651,7 +651,7 @@ function twentytwenty_get_elements_array() {
 				'background' => array( '.social-icons a', '#site-footer button:not(.toggle)', '#site-footer .button', '#site-footer .faux-button', '#site-footer .wp-block-button__link', '#site-footer .wp-block-file__button', '#site-footer input[type="button"]', '#site-footer input[type="reset"]', '#site-footer input[type="submit"]' ),
 			),
 			'background' => array(
-				'color'      => array( '.social-icons a', '.overlay-header:not(.showing-menu-modal) .header-inner', '.primary-menu ul', '.header-footer-group button', '.header-footer-group .button', '.header-footer-group .faux-button', '.header-footer-group .wp-block-button:not(.is-style-outline) .wp-block-button__link', '.header-footer-group .wp-block-file__button', '.header-footer-group input[type="button"]', '.header-footer-group input[type="reset"]', '.header-footer-group input[type="submit"]' ),
+				'color'      => array( '.social-icons a', '.overlay-header .header-inner', '.primary-menu ul', '.header-footer-group button', '.header-footer-group .button', '.header-footer-group .faux-button', '.header-footer-group .wp-block-button:not(.is-style-outline) .wp-block-button__link', '.header-footer-group .wp-block-file__button', '.header-footer-group input[type="button"]', '.header-footer-group input[type="reset"]', '.header-footer-group input[type="submit"]' ),
 				'background' => array( '#site-header', '#site-footer', '.menu-modal', '.menu-modal-inner', '.search-modal-inner', '.archive-header', '.singular .entry-header', '.singular .featured-media:before', '.wp-block-pullquote:before' ),
 			),
 			'text'       => array(

--- a/inc/custom-css.php
+++ b/inc/custom-css.php
@@ -106,6 +106,7 @@ if ( ! function_exists( 'twentytwenty_get_customizer_css' ) ) {
 			}
 
 			if ( $cover && $cover !== $cover_default ) {
+				twentytwenty_generate_css( '.overlay-header .header-inner', 'color', $cover );
 				twentytwenty_generate_css( '.cover-header .entry-header *', 'color', $cover );
 			}
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1597,8 +1597,7 @@ body:not(.enable-search-modal) .site-logo img {
 	}
 }
 
-.overlay-header:not(.showing-menu-modal):not(.overlay-header-has-text-color) .header-inner,
-.overlay-header:not(.showing-menu-modal) .header-inner {
+.overlay-header .header-inner {
 	color: #fff;
 }
 

--- a/style.css
+++ b/style.css
@@ -1595,7 +1595,7 @@ body:not(.enable-search-modal) .site-logo img {
 
 .overlay-header .header-inner .toggle-wrapper::before {
 	background-color: currentColor;
-	opacity: .25;
+	opacity: 0.25;
 }
 
 .admin-bar.overlay-header #site-header {

--- a/style.css
+++ b/style.css
@@ -1584,8 +1584,18 @@ body:not(.enable-search-modal) .site-logo img {
 	z-index: 100;
 }
 
-.overlay-header .header-inner * {
+.overlay-header .header-inner {
+	color: #fff;
+}
+
+.overlay-header .site-description,
+.overlay-header .toggle {
 	color: inherit;
+}
+
+.overlay-header .header-inner .toggle-wrapper::before {
+	background-color: currentColor;
+	opacity: .25;
 }
 
 .admin-bar.overlay-header #site-header {
@@ -1597,11 +1607,6 @@ body:not(.enable-search-modal) .site-logo img {
 	.admin-bar.overlay-header #site-header {
 		top: 46px;
 	}
-}
-
-.overlay-header:not(.showing-menu-modal):not(.overlay-header-has-text-color) .header-inner,
-.overlay-header:not(.showing-menu-modal) .header-inner {
-	color: #fff;
 }
 
 /* Header Navigation ------------------------- */
@@ -5316,26 +5321,11 @@ a.to-the-top > * {
 	}
 
 	.toggle-inner .toggle-text {
-		color: #6d6d6d;
 		left: 0;
 		right: 0;
 		text-align: center;
 		top: calc(100% - 0.3rem);
 		width: auto;
-	}
-
-	/* OVERLAY HEADER */
-
-	.overlay-header.showing-menu-modal .header-inner {
-		color: #fff;
-	}
-
-	.overlay-header .toggle-wrapper::before {
-		background: rgba(255, 255, 255, 0.33);
-	}
-
-	.overlay-header .toggle-inner .toggle-text {
-		color: inherit;
 	}
 
 	/* Menu Modal ---------------------------- */


### PR DESCRIPTION
Fixes the text color selected on the "Cover Template" Customizer panel not applying to the site header when a cover template is viewed. I thought there was an issue for this, but I can't find it now.

**Before:**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/8181091/65816320-5c697700-e1fa-11e9-877a-25457e0eb69b.png">

**After:**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/8181091/65816326-68553900-e1fa-11e9-9ab1-24ceb4e599d8.png">