### PR TITLE
Update edit comment link to be less pronounced

### DIFF
--- a/classes/class-twentytwenty-walker-comment.php
+++ b/classes/class-twentytwenty-walker-comment.php
@@ -69,6 +69,11 @@ if ( ! class_exists( 'TwentyTwenty_Walker_Comment' ) ) {
 									<?php echo esc_html( $comment_timestamp ); ?>
 								</time>
 							</a>
+							<?php
+							if ( get_edit_comment_link() ) {
+								echo ' &bull; <a class="comment-edit-link" href="' . esc_url( get_edit_comment_link() ) . '">' . __( 'Edit', 'twentytwenty' ) . '</a>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- core trusts translations
+							}
+							?>
 						</div><!-- .comment-metadata -->
 
 					</footer><!-- .comment-meta -->
@@ -84,6 +89,7 @@ if ( ! class_exists( 'TwentyTwenty_Walker_Comment' ) ) {
 							<p class="comment-awaiting-moderation"><?php _e( 'Your comment is awaiting moderation.', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></p>
 							<?php
 						}
+
 						?>
 
 					</div><!-- .comment-content -->
@@ -105,9 +111,7 @@ if ( ! class_exists( 'TwentyTwenty_Walker_Comment' ) ) {
 
 					$by_post_author = twentytwenty_is_comment_by_post_author( $comment );
 
-					$edit_comment_link = get_edit_comment_link() ? '<a class="edit-comment-link" href="' . esc_url( get_edit_comment_link() ) . '">' . __( 'Edit', 'twentytwenty' ) . '</a>' : '';
-
-					if ( $comment_reply_link || $by_post_author || $edit_comment_link ) {
+					if ( $comment_reply_link || $by_post_author ) {
 						?>
 
 						<footer class="comment-footer-meta">
@@ -115,9 +119,6 @@ if ( ! class_exists( 'TwentyTwenty_Walker_Comment' ) ) {
 							<?php
 							if ( $comment_reply_link ) {
 								echo $comment_reply_link; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped --Link is escaped in https://developer.wordpress.org/reference/functions/get_comment_reply_link/
-							}
-							if ( $edit_comment_link ) {
-								echo $edit_comment_link; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped --Link escaped on line 109.
 							}
 							if ( $by_post_author ) {
 								echo '<span class="by-post-author">' . __( 'By Post Author', 'twentytwenty' ) . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- core trusts translations

--- a/functions.php
+++ b/functions.php
@@ -625,11 +625,11 @@ function twentytwenty_get_elements_array() {
 				'color'            => array( '.color-accent', '.color-accent-hover:hover', '.color-accent-hover:focus', '.has-accent-color', '.has-drop-cap:not(:focus):first-letter', '.wp-block-button.is-style-outline', 'a' ),
 				'border-color'     => array( 'blockquote', '.border-color-accent', '.border-color-accent-hover:hover', '.border-color-accent-hover:focus' ),
 				'background'       => array( 'button:not(.toggle)', '.button', '.faux-button', '.wp-block-button__link', '.wp-block-file__button', 'input[type="button"]', 'input[type="reset"]', 'input[type="submit"]' ),
-				'background-color' => array( '.bg-accent', '.bg-accent-hover:hover', '.bg-accent-hover:focus', '.has-accent-background-color', '.comment-reply-link', '.edit-comment-link' ),
+				'background-color' => array( '.bg-accent', '.bg-accent-hover:hover', '.bg-accent-hover:focus', '.has-accent-background-color', '.comment-reply-link' ),
 				'fill'             => array( '.fill-children-accent', '.fill-children-accent *' ),
 			),
 			'background' => array(
-				'color'      => array( 'button', '.button', '.faux-button', '.wp-block-button__link', '.wp-block-file__button', 'input[type="button"]', 'input[type="reset"]', 'input[type="submit"]', '.comment-reply-link', '.edit-comment-link' ),
+				'color'      => array( 'button', '.button', '.faux-button', '.wp-block-button__link', '.wp-block-file__button', 'input[type="button"]', 'input[type="reset"]', 'input[type="submit"]', '.comment-reply-link' ),
 				'background' => array(),
 			),
 			'text'       => array(

--- a/style.css
+++ b/style.css
@@ -3685,8 +3685,7 @@ div.comment:first-of-type {
 	margin: 0 0 1rem 1.5rem;
 }
 
-.comment-reply-link,
-.edit-comment-link {
+.comment-reply-link {
 	background-color: #cd2653;
 	color: #fff;
 	display: block;
@@ -5005,7 +5004,7 @@ a.to-the-top > * {
 	.comment-meta {
 		margin-bottom: 2rem;
 		min-height: 6rem;
-		padding: 0.2rem 0 0 7.5rem;
+		padding: 0.3rem 0 0 7.5rem;
 	}
 
 	.comment-meta .avatar {


### PR DESCRIPTION
Updates the edit comment link to be less pronounced, and more distinctive from the reply button. Fixes #602.

**Before:**
<img width="506" alt="image" src="https://user-images.githubusercontent.com/8181091/65816523-05b16c80-e1fd-11e9-9444-3590388592a5.png">

**After:**
<img width="462" alt="image" src="https://user-images.githubusercontent.com/8181091/65816515-f7635080-e1fc-11e9-8541-d82feafd1534.png">
