### PR TITLE
Use HTML5 meta charset

### DIFF
--- a/header.php
+++ b/header.php
@@ -16,7 +16,7 @@
 
 	<head>
 
-		<meta http-equiv="content-type" content="<?php bloginfo( 'html_type' ); ?>" charset="<?php bloginfo( 'charset' ); ?>" />
+		<meta charset="<?php bloginfo( 'charset' ); ?>">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" >
 
 		<link rel="profile" href="https://gmpg.org/xfn/11">


### PR DESCRIPTION
Currently the theme has an HTML4 `meta` tag for `Content-Type`, but all of the core themes use the HTML5 `meta[charset]`, for example:

```php
<meta charset="<?php bloginfo( 'charset' ); ?>">
```

This PR aligns the `meta` tag with the other core themes.