### PR TITLE
Updated the footer structure

### DIFF
--- a/404.php
+++ b/404.php
@@ -12,7 +12,7 @@ get_header();
 
 <main id="site-content" role="main">
 
-	<div class="section-inner thin">
+	<div class="section-inner thin error404-content">
 
 		<h1 class="entry-title"><?php _e( 'Page Not Found', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></h1>
 
@@ -27,6 +27,8 @@ get_header();
 		?>
 
 	</div><!-- .section-inner -->
+
+	<?php get_template_part( 'template-parts/footer-menus-widgets' ); ?>
 
 </main><!-- #site-content -->
 

--- a/footer.php
+++ b/footer.php
@@ -11,158 +11,53 @@
  * @since 1.0.0
  */
 
-?>
-
+?>		
 		<footer id="site-footer" role="contentinfo" class="header-footer-group">
 
-			<div class="footer-inner section-inner">
+			<div class="footer-bottom section-inner">
 
-				<?php
+				<div class="footer-credits">
 
-				$has_footer_menu = has_nav_menu( 'footer' );
-				$has_social_menu = has_nav_menu( 'social' );
+					<p class="footer-copyright">&copy;
+						<?php
+						echo esc_html(
+							date_i18n(
+								/* Translators: Y = Format parameter for date() https://php.net/manual/en/function.date.php */
+								_x( 'Y', 'Translators: Y = Current year', 'twentytwenty' )
+							)
+						);
+						?>
+						<a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php echo bloginfo( 'name' ); ?></a>
+					</p>
 
-				$footer_top_classes = '';
-
-				$footer_top_classes .= $has_footer_menu ? ' has-footer-menu' : '';
-				$footer_top_classes .= $has_social_menu ? ' has-social-menu' : '';
-
-				$footer_social_wrapper_class = $has_footer_menu ? 'footer-social-wrapper' : '';
-
-				if ( $has_footer_menu || $has_social_menu ) {
-					?>
-					<div class="footer-top<?php echo esc_attr( $footer_top_classes ); ?>">
-						<?php if ( $has_footer_menu ) { ?>
-
-							<nav aria-label="<?php esc_attr_e( 'Footer menu', 'twentytwenty' ); ?>">
-
-								<ul class="footer-menu reset-list-style">
-									<?php
-									wp_nav_menu(
-										array(
-											'container'  => '',
-											'depth'      => 1,
-											'items_wrap' => '%3$s',
-											'theme_location' => 'footer',
-										)
-									);
-									?>
-								</ul>
-
-							</nav><!-- .site-nav -->
-
-						<?php } ?>
-						<?php if ( $has_social_menu ) { ?>
-
-							<div class="<?php echo esc_attr( $footer_social_wrapper_class ); ?>">
-
-								<nav aria-label="<?php esc_attr_e( 'Social links', 'twentytwenty' ); ?>">
-
-									<ul class="social-menu footer-social reset-list-style social-icons s-icons">
-
-										<?php
-										wp_nav_menu(
-											array(
-												'theme_location' => 'social',
-												'container' => '',
-												'container_class' => '',
-												'items_wrap' => '%3$s',
-												'menu_id' => '',
-												'menu_class' => '',
-												'depth'   => 1,
-												'link_before' => '<span class="screen-reader-text">',
-												'link_after' => '</span>',
-												'fallback_cb' => '',
-											)
-										);
-										?>
-
-									</ul>
-
-								</nav><!-- .social-menu -->
-
-							</div><!-- .footer-social-wrapper -->
-
-						<?php } ?>
-					</div><!-- .footer-top -->
-
-				<?php } ?>
-
-
-				<?php if ( is_active_sidebar( 'sidebar-1' ) || is_active_sidebar( 'sidebar-2' ) ) { ?>
-
-					<div class="footer-widgets-outer-wrapper">
-
-						<div class="footer-widgets-wrapper">
-
-							<?php if ( is_active_sidebar( 'sidebar-1' ) ) { ?>
-
-								<div class="footer-widgets column-one grid-item">
-									<?php dynamic_sidebar( 'sidebar-1' ); ?>
-								</div>
-
-							<?php } ?>
-
-							<?php if ( is_active_sidebar( 'sidebar-2' ) ) { ?>
-
-								<div class="footer-widgets column-two grid-item">
-									<?php dynamic_sidebar( 'sidebar-2' ); ?>
-								</div>
-
-							<?php } ?>
-
-						</div><!-- .footer-widgets-wrapper -->
-
-					</div><!-- .footer-widgets-outer-wrapper -->
-
-				<?php } ?>
-
-				<div class="footer-bottom">
-
-					<div class="footer-credits">
-
-						<p class="footer-copyright">&copy;
+					<p class="powered-by-wordpress">
+						<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentytwenty' ) ); ?>">
 							<?php
-							echo esc_html(
-								date_i18n(
-									/* Translators: Y = Format parameter for date() https://php.net/manual/en/function.date.php */
-									_x( 'Y', 'Translators: Y = Current year', 'twentytwenty' )
-								)
-							);
+							_e( 'Powered by WordPress', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations
 							?>
-							<a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php echo bloginfo( 'name' ); ?></a>
-						</p>
+						</a>
+					</p><!-- .theme-credits -->
 
-						<p class="powered-by-wordpress">
-							<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentytwenty' ) ); ?>">
-								<?php
-								_e( 'Powered by WordPress', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations
-								?>
-							</a>
-						</p><!-- .theme-credits -->
+				</div><!-- .footer-credits -->
 
-					</div><!-- .footer-credits -->
+				<a class="to-the-top" href="#site-header">
+					<span class="to-the-top-long">
+						<?php
+						// Translators: %s = HTML character for an arrow.
+						printf( esc_html( _x( 'To the top %s', '%s = HTML character for an arrow', 'twentytwenty' ) ), '<span class="arrow">&uarr;</span>' );
+						?>
+					</span>
+					<span class="to-the-top-short">
+						<?php
+						// Translators: %s = HTML character for an arrow.
+						printf( esc_html( _x( 'Up %s', '%s = HTML character for an arrow', 'twentytwenty' ) ), '<span class="arrow">&uarr;</span>' );
+						?>
+					</span>
+				</a>
 
-					<a class="to-the-top" href="#site-header">
-						<span class="to-the-top-long">
-							<?php
-							// Translators: %s = HTML character for an arrow.
-							printf( esc_html( _x( 'To the top %s', '%s = HTML character for an arrow', 'twentytwenty' ) ), '<span class="arrow">&uarr;</span>' );
-							?>
-						</span>
-						<span class="to-the-top-short">
-							<?php
-							// Translators: %s = HTML character for an arrow.
-							printf( esc_html( _x( 'Up %s', '%s = HTML character for an arrow', 'twentytwenty' ) ), '<span class="arrow">&uarr;</span>' );
-							?>
-						</span>
-					</a>
+			</div><!-- .footer-bottom -->
 
-				</div><!-- .footer-bottom -->
-
-			</div><!-- .footer-inner -->
-
-		</footer><!-- #site-footer -->
+			</footer><!-- #site-footer -->
 
 		<?php wp_footer(); ?>
 

--- a/footer.php
+++ b/footer.php
@@ -12,50 +12,50 @@
  */
 
 ?>		
-		<footer id="site-footer" role="contentinfo" class="header-footer-group">
+			<footer id="site-footer" role="contentinfo" class="header-footer-group">
 
-			<div class="footer-bottom section-inner">
+				<div class="section-inner">
 
-				<div class="footer-credits">
+					<div class="footer-credits">
 
-					<p class="footer-copyright">&copy;
-						<?php
-						echo esc_html(
-							date_i18n(
-								/* Translators: Y = Format parameter for date() https://php.net/manual/en/function.date.php */
-								_x( 'Y', 'Translators: Y = Current year', 'twentytwenty' )
-							)
-						);
-						?>
-						<a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php echo bloginfo( 'name' ); ?></a>
-					</p>
-
-					<p class="powered-by-wordpress">
-						<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentytwenty' ) ); ?>">
+						<p class="footer-copyright">&copy;
 							<?php
-							_e( 'Powered by WordPress', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations
+							echo esc_html(
+								date_i18n(
+									/* Translators: Y = Format parameter for date() https://php.net/manual/en/function.date.php */
+									_x( 'Y', 'Translators: Y = Current year', 'twentytwenty' )
+								)
+							);
 							?>
-						</a>
-					</p><!-- .theme-credits -->
+							<a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php echo bloginfo( 'name' ); ?></a>
+						</p>
 
-				</div><!-- .footer-credits -->
+						<p class="powered-by-wordpress">
+							<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentytwenty' ) ); ?>">
+								<?php
+								_e( 'Powered by WordPress', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations
+								?>
+							</a>
+						</p><!-- .theme-credits -->
 
-				<a class="to-the-top" href="#site-header">
-					<span class="to-the-top-long">
-						<?php
-						// Translators: %s = HTML character for an arrow.
-						printf( esc_html( _x( 'To the top %s', '%s = HTML character for an arrow', 'twentytwenty' ) ), '<span class="arrow">&uarr;</span>' );
-						?>
-					</span>
-					<span class="to-the-top-short">
-						<?php
-						// Translators: %s = HTML character for an arrow.
-						printf( esc_html( _x( 'Up %s', '%s = HTML character for an arrow', 'twentytwenty' ) ), '<span class="arrow">&uarr;</span>' );
-						?>
-					</span>
-				</a>
+					</div><!-- .footer-credits -->
 
-			</div><!-- .footer-bottom -->
+					<a class="to-the-top" href="#site-header">
+						<span class="to-the-top-long">
+							<?php
+							// Translators: %s = HTML character for an arrow.
+							printf( esc_html( _x( 'To the top %s', '%s = HTML character for an arrow', 'twentytwenty' ) ), '<span class="arrow">&uarr;</span>' );
+							?>
+						</span>
+						<span class="to-the-top-short">
+							<?php
+							// Translators: %s = HTML character for an arrow.
+							printf( esc_html( _x( 'Up %s', '%s = HTML character for an arrow', 'twentytwenty' ) ), '<span class="arrow">&uarr;</span>' );
+							?>
+						</span>
+					</a>
+
+				</div><!-- .section-inner -->
 
 			</footer><!-- #site-footer -->
 

--- a/functions.php
+++ b/functions.php
@@ -652,7 +652,7 @@ function twentytwenty_get_elements_array() {
 			),
 			'background' => array(
 				'color'      => array( '.social-icons a', '.overlay-header .header-inner', '.primary-menu ul', '.header-footer-group button', '.header-footer-group .button', '.header-footer-group .faux-button', '.header-footer-group .wp-block-button:not(.is-style-outline) .wp-block-button__link', '.header-footer-group .wp-block-file__button', '.header-footer-group input[type="button"]', '.header-footer-group input[type="reset"]', '.header-footer-group input[type="submit"]' ),
-				'background' => array( '#site-header', '#site-footer', '.menu-modal', '.menu-modal-inner', '.search-modal-inner', '.archive-header', '.singular .entry-header', '.singular .featured-media:before', '.wp-block-pullquote:before' ),
+				'background' => array( '#site-header', '.footer-nav-widgets-wrapper', '#site-footer', '.menu-modal', '.menu-modal-inner', '.search-modal-inner', '.archive-header', '.singular .entry-header', '.singular .featured-media:before', '.wp-block-pullquote:before' ),
 			),
 			'text'       => array(
 				'color'               => array( '.header-footer-group', 'body:not(.overlay-header) #site-header .toggle', '.menu-modal .toggle' ),
@@ -664,7 +664,7 @@ function twentytwenty_get_elements_array() {
 				'color' => array( '.site-description', 'body:not(.overlay-header) .toggle-inner .toggle-text', '.widget .post-date', '.widget .rss-date', '.widget_archive li', '.widget_categories li', '.widget cite', '.widget_pages li', '.widget_meta li', '.widget_nav_menu li', '.powered-by-wordpress', '.to-the-top', '.singular .entry-header .post-meta', '.singular:not(.overlay-header) .entry-header .post-meta a' ),
 			),
 			'borders'    => array(
-				'border-color' => array( '.header-footer-group pre', '.header-footer-group fieldset', '.header-footer-group input', '.header-footer-group textarea', '.header-footer-group table', '.header-footer-group table *', '.reduced-spacing #site-footer', '.menu-modal nav *', '.footer-widgets-outer-wrapper', '.footer-top' ),
+				'border-color' => array( '.header-footer-group pre', '.header-footer-group fieldset', '.header-footer-group input', '.header-footer-group textarea', '.header-footer-group table', '.header-footer-group table *', '.footer-nav-widgets-wrapper', '#site-footer', '.menu-modal nav *', '.footer-widgets-outer-wrapper', '.footer-top' ),
 				'background'   => array( '.header-footer-group table caption', 'body:not(.overlay-header) .header-inner .toggle-wrapper::before' ),
 			),
 		),

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -642,6 +642,19 @@ function twentytwenty_body_classes( $classes ) {
 		$classes[] = basename( get_page_template_slug(), '.php' );
 	}
 
+	// Check for the elements output in the top part of the footer.
+	$has_footer_menu = has_nav_menu( 'footer' );
+	$has_social_menu = has_nav_menu( 'social' );
+	$has_sidebar_1   = is_active_sidebar( 'sidebar-1' );
+	$has_sidebar_2   = is_active_sidebar( 'sidebar-2' );
+
+	// Add a class indicating whether those elements are output.
+	if ( $has_footer_menu || $has_social_menu || $has_sidebar_1 || $has_sidebar_2 ) {
+		$classes[] = 'footer-top-visible';
+	} else {
+		$classes[] = 'footer-top-hidden';
+	}
+
 	// Get header/footer background color.
 	$header_footer_background = get_theme_mod( 'header_footer_background_color', '#ffffff' );
 	$header_footer_background = strtolower( '#' . ltrim( $header_footer_background, '#' ) );

--- a/index.php
+++ b/index.php
@@ -100,6 +100,7 @@ get_header();
 	?>
 
 	<?php get_template_part( 'template-parts/pagination' ); ?>
+	<?php get_template_part( 'template-parts/footer-menus-widgets' ); ?>
 
 </main><!-- #site-content -->
 

--- a/singular.php
+++ b/singular.php
@@ -25,6 +25,8 @@ get_header();
 		}
 	}
 
+	get_template_part( 'template-parts/footer-menus-widgets' );
+
 	?>
 
 </main><!-- #site-content -->

--- a/style.css
+++ b/style.css
@@ -3952,6 +3952,9 @@ div.comment:first-of-type {
 
 .error404 #site-content {
 	padding-top: 4rem;
+}
+
+.error404-content {
 	text-align: center;
 }
 
@@ -4235,12 +4238,18 @@ div.comment:first-of-type {
 /* -------------------------------------------------------------------------- */
 
 
+.footer-nav-widgets-wrapper,
 #site-footer {
 	background-color: #fff;
+}
+
+.footer-top-visible .footer-nav-widgets-wrapper,
+.footer-top-hidden #site-footer {
 	margin-top: 5rem;
 }
 
-.reduced-spacing #site-footer {
+.reduced-spacing.footer-top-visible .footer-nav-widgets-wrapper,
+.reduced-spacing.footer-top-hidden #site-footer {
 	border-top: 0.1rem solid #dedfdf;
 }
 
@@ -5191,7 +5200,8 @@ a.to-the-top > * {
 
 	/* Site Footer --------------------------- */
 
-	#site-footer {
+	.footer-top-visible .footer-nav-widgets-wrapper,
+	.footer-top-hidden #site-footer {
 		margin-top: 8rem;
 	}
 

--- a/style.css
+++ b/style.css
@@ -4255,7 +4255,7 @@ div.comment:first-of-type {
 
 .footer-top,
 .footer-widgets-outer-wrapper,
-.footer-bottom {
+#site-footer {
 	padding: 3rem 0;
 }
 
@@ -4329,19 +4329,22 @@ ul.footer-social li {
 
 /* Footer Bottom ----------------------------- */
 
-.footer-bottom {
-	align-items: baseline;
-	display: flex;
-	justify-content: space-between;
+#site-footer {
 	font-size: 1.6rem;
 }
 
-.footer-bottom a {
+#site-footer .section-inner {
+	align-items: baseline;
+	display: flex;
+	justify-content: space-between;
+}
+
+#site-footer a {
 	text-decoration: none;
 }
 
-.footer-bottom a:focus,
-.footer-bottom a:hover {
+#site-footer a:focus,
+#site-footer a:hover {
 	text-decoration: underline;
 }
 
@@ -5259,7 +5262,7 @@ a.to-the-top > * {
 
 	/* FOOTER BOTTOM */
 
-	.footer-bottom {
+	#site-footer {
 		font-size: 1.8rem;
 		padding: 4.3rem 0;
 	}

--- a/template-parts/footer-menus-widgets.php
+++ b/template-parts/footer-menus-widgets.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Displays the menus and widgets at the end of the main element.
+ * Visually, this output is presented as part of the footer element.
+ *
+ * @package WordPress
+ * @subpackage Twenty_Twenty
+ * @since 1.0.0
+ */
+
+$has_footer_menu = has_nav_menu( 'footer' );
+$has_social_menu = has_nav_menu( 'social' );
+
+$has_sidebar_1 = is_active_sidebar( 'sidebar-1' );
+$has_sidebar_2 = is_active_sidebar( 'sidebar-2' );
+
+// Only output the container if there are elements to display.
+if ( $has_footer_menu || $has_social_menu || $has_sidebar_1 || $has_sidebar_2 ) {
+	?>
+
+	<div class="footer-nav-widgets-wrapper header-footer-group">
+
+		<div class="footer-inner section-inner">
+
+			<?php
+
+			$footer_top_classes = '';
+
+			$footer_top_classes .= $has_footer_menu ? ' has-footer-menu' : '';
+			$footer_top_classes .= $has_social_menu ? ' has-social-menu' : '';
+
+			$footer_social_wrapper_class = $has_footer_menu ? 'footer-social-wrapper' : '';
+
+			if ( $has_footer_menu || $has_social_menu ) {
+				?>
+				<div class="footer-top<?php echo esc_attr( $footer_top_classes ); ?>">
+					<?php if ( $has_footer_menu ) { ?>
+
+						<nav aria-label="<?php esc_attr_e( 'Footer', 'twentytwenty' ); ?>" role="navigation">
+
+							<ul class="footer-menu reset-list-style">
+								<?php
+								wp_nav_menu(
+									array(
+										'container'      => '',
+										'depth'          => 1,
+										'items_wrap'     => '%3$s',
+										'theme_location' => 'footer',
+									)
+								);
+								?>
+							</ul>
+
+						</nav><!-- .site-nav -->
+
+					<?php } ?>
+					<?php if ( $has_social_menu ) { ?>
+
+						<div class="<?php echo esc_attr( $footer_social_wrapper_class ); ?>">
+
+							<nav aria-label="<?php esc_attr_e( 'Social links', 'twentytwenty' ); ?>">
+
+								<ul class="social-menu footer-social reset-list-style social-icons s-icons">
+
+									<?php
+									wp_nav_menu(
+										array(
+											'theme_location' => 'social',
+											'container'   => '',
+											'container_class' => '',
+											'items_wrap'  => '%3$s',
+											'menu_id'     => '',
+											'menu_class'  => '',
+											'depth'       => 1,
+											'link_before' => '<span class="screen-reader-text">',
+											'link_after'  => '</span>',
+											'fallback_cb' => '',
+										)
+									);
+									?>
+
+								</ul>
+
+							</nav><!-- .social-menu -->
+
+						</div><!-- .footer-social-wrapper -->
+
+					<?php } ?>
+				</div><!-- .footer-top -->
+
+			<?php } ?>
+
+			<?php if ( $has_sidebar_1 || $has_sidebar_2 ) { ?>
+
+				<aside class="footer-widgets-outer-wrapper" role="complementary">
+
+					<div class="footer-widgets-wrapper">
+
+						<?php if ( $has_sidebar_1 ) { ?>
+
+							<div class="footer-widgets column-one grid-item">
+								<?php dynamic_sidebar( 'sidebar-1' ); ?>
+							</div>
+
+						<?php } ?>
+
+						<?php if ( $has_sidebar_2 ) { ?>
+
+							<div class="footer-widgets column-two grid-item">
+								<?php dynamic_sidebar( 'sidebar-2' ); ?>
+							</div>
+
+						<?php } ?>
+
+					</div><!-- .footer-widgets-wrapper -->
+
+				</aside><!-- .footer-widgets-outer-wrapper -->
+
+			<?php } ?>
+
+		</div><!-- .footer-inner -->
+
+	</div><!-- .footer-nav-widgets-wrapper -->
+
+<?php } ?>

--- a/templates/template-cover.php
+++ b/templates/template-cover.php
@@ -24,6 +24,8 @@ get_header();
 		}
 	}
 
+	get_template_part( 'template-parts/footer-menus-widgets' );
+
 	?>
 
 </main><!-- #site-content -->


### PR DESCRIPTION
This PR updates the footer structure per #564, based on the description by @afercia in #465.

The footer menus and widgets are moved to their own template part, `template-parts/footer-menus-widgets.php`, which is included in the bottom of the `<main>` element on all pages. That leaves the `<footer>` element with just the copyright text, "Powered by WordPress" and "To the top". 

Other changes:
- Changed the widget wrapper to an `aside` element with `role="complementary"`
- Added `role="navigation"` to the footer menu `nav` element
- Changed the `aria-label` on the footer menu `nav` element from "Footer menu" to just "Footer"
- Added a conditional body class indicating whether the top footer margin should be on the `<footer>` or on the `.footer-nav-widgets-wrapper`
- Fixes styling issue on the 404 page caused by `text-align: center` on the 404 `main` element
- Updated styles and a11y colors

Fixes #564.