### PR TITLE
Removed conditional around output of close modal button

### DIFF
--- a/template-parts/modal-menu.php
+++ b/template-parts/modal-menu.php
@@ -17,19 +17,12 @@
 
 			<div class="menu-top">
 
-				<?php 
+				<button class="toggle close-nav-toggle fill-children-current-color" data-toggle-target=".menu-modal" data-toggle-screen-lock="true" data-toggle-body-class="showing-menu-modal" aria-expanded="false" data-set-focus=".menu-modal">
+					<span class="toggle-text"><?php esc_html_e( 'Close Menu', 'twentytwenty' ); ?></span>
+					<?php twentytwenty_the_theme_svg( 'cross' ); ?>
+				</button><!-- .nav-toggle -->
 
-				// If the expanded menu is set, output the close button.
-				if ( has_nav_menu( 'expanded' ) ) { 
-					?>
-
-					<button class="toggle close-nav-toggle fill-children-current-color" data-toggle-target=".menu-modal" data-toggle-screen-lock="true" data-toggle-body-class="showing-menu-modal" aria-expanded="false" data-set-focus=".menu-modal">
-						<span class="toggle-text"><?php esc_html_e( 'Close Menu', 'twentytwenty' ); ?></span>
-						<?php twentytwenty_the_theme_svg( 'cross' ); ?>
-					</button><!-- .nav-toggle -->
-
-					<?php
-				}
+				<?php
 
 				$mobile_menu_location = '';
 


### PR DESCRIPTION
Removed a conditional for `has_nav_menu( 'expanded' )` around the output of the "Close Menu" button, since the button should always be output now.