### PR TITLE
Update aria label and markup for the horizontal menu

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -445,7 +445,7 @@ twentytwenty.primaryMenu = {
 	// by adding the '.focus' class to all 'li.menu-item-has-children' when the focus is on the 'a' element.
 	focusMenuWithChildren: function() {
 		// Get all the link elements within the primary menu.
-		var menu = document.querySelector( '.primary-menu-wrapper nav' );
+		var menu = document.querySelector( '.primary-menu-wrapper' );
 		var links = menu.getElementsByTagName( 'a' );
 		var i, len;
 

--- a/header.php
+++ b/header.php
@@ -86,7 +86,7 @@
 					if ( has_nav_menu( 'primary' ) || ! has_nav_menu( 'expanded' ) ) {
 						?>
 
-							<nav class="primary-menu-wrapper" aria-label="<?php esc_attr_e( 'Horizontal', 'twentytwenty' ); ?>">
+							<nav class="primary-menu-wrapper" aria-label="<?php esc_attr_e( 'Horizontal', 'twentytwenty' ); ?>" role="navigation">
 
 								<ul class="primary-menu reset-list-style">
 

--- a/header.php
+++ b/header.php
@@ -86,9 +86,7 @@
 					if ( has_nav_menu( 'primary' ) || ! has_nav_menu( 'expanded' ) ) {
 						?>
 
-						<div class="primary-menu-wrapper">
-
-							<nav aria-label="<?php esc_attr_e( 'Primary', 'twentytwenty' ); ?>">
+							<nav class="primary-menu-wrapper" aria-label="<?php esc_attr_e( 'Horizontal', 'twentytwenty' ); ?>">
 
 								<ul class="primary-menu reset-list-style">
 
@@ -119,9 +117,7 @@
 
 								</ul>
 
-							</nav><!-- .primary-menu -->
-
-						</div><!-- .primary-menu-wrapper -->
+							</nav><!-- .primary-menu-wrapper -->
 
 						<?php
 					}


### PR DESCRIPTION
Update the aria label for the horizontal menu from "Primary" to "Horizontal" so that the names on the front and admin match each other better.

Simplifies the markup for the menu by removing an extra div.
Fixes https://github.com/WordPress/twentytwenty/issues/73