### PR TITLE
Doctype should be the very first character of the html page

### DIFF
--- a/header.php
+++ b/header.php
@@ -9,8 +9,7 @@
  * @since 1.0.0
  */
 
-?>
-<!DOCTYPE html>
+?><!DOCTYPE html>
 
 <html class="no-js" <?php language_attributes(); ?>>
 


### PR DESCRIPTION
Not a big deal, but `doctype` declaration should be the very first thing in the generated HTML document.