### PR TITLE
Fix: Search query term is not visible in the search input field

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -21,7 +21,7 @@ $aria_label = ( isset( $args['label'] ) && ! empty( $args['label'] ) ) ? 'aria-l
 <form role="search" <?php echo $aria_label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above. ?> method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<label for="<?php echo esc_attr( $unique_id ); ?>">
 		<span class="screen-reader-text"><?php echo _x( 'Search for:', 'label', 'twentytwenty' ); // phpcs:ignore: WordPress.Security.EscapeOutput.OutputNotEscaped -- core trusts translations ?></span>
-		<input type="search" id="<?php echo esc_attr( $unique_id ); ?>" class="search-field" placeholder="<?php echo esc_attr_x( 'Search &hellip;', 'placeholder', 'twentytwenty' ); ?>" value="<?php get_search_query(); ?>" name="s" />
+		<input type="search" id="<?php echo esc_attr( $unique_id ); ?>" class="search-field" placeholder="<?php echo esc_attr_x( 'Search &hellip;', 'placeholder', 'twentytwenty' ); ?>" value="<?php echo get_search_query(); ?>" name="s" />
 	</label>
 	<input type="submit" class="search-submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'twentytwenty' ); ?>" />
 </form>


### PR DESCRIPTION
The search query term is not visible in the search input field.

If we search any tern then it is visible in the search input.

E.g. If we search `testing` then it is visible in the search box.

See screenshot of theme Twenty Nineteen:
![Theme Twenty Nineteen]( https://maheshwaghmare.files.wordpress.com/2019/10/image-2019-10-01-at-6.08.34-pm.png)

But, It is not visible in TwentyTwenty.

See screenshot - (Before Fix Theme TwentyTwenty):
![Before Fix Theme Twenty Twenty](https://maheshwaghmare.files.wordpress.com/2019/10/image-2019-10-01-at-6.10.51-pm.png)

---

The issue is in file `twentytwenty/searchform.php` line 24 the code is:

```
value="<?php get_search_query(); ?>"
```

This should be:
```
value="<?php echo get_search_query(); ?>"
```

After issue fix screenshot (After Fix Theme TwentyTwenty):
![After Fix Theme Twenty Twenty](https://maheshwaghmare.files.wordpress.com/2019/10/image-2019-10-01-at-6.16.32-pm.png)
