### PR TITLE
Add a span to page numbers

### DIFF
--- a/template-parts/content-cover.php
+++ b/template-parts/content-cover.php
@@ -133,11 +133,12 @@
 
 		</div><!-- .entry-content -->
 		<?php
-
 		wp_link_pages(
 			array(
-				'before' => '<nav class="post-nav-links bg-light-background" aria-label="' . esc_attr__( 'Page', 'twentytwenty' ) . '"><span class="label">' . __( 'Pages:', 'twentytwenty' ) . '</span>',
-				'after'  => '</nav>',
+				'before'      => '<nav class="post-nav-links bg-light-background" aria-label="' . esc_attr__( 'Page', 'twentytwenty' ) . '"><span class="label">' . __( 'Pages:', 'twentytwenty' ) . '</span>',
+				'after'       => '</nav>',
+				'link_before' => '<span class="page-number">',
+				'link_after'  => '</span>',
 			)
 		);
 

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -40,11 +40,12 @@
 		</div><!-- .entry-content -->
 
 		<?php
-
 		wp_link_pages(
 			array(
-				'before' => '<nav class="post-nav-links bg-light-background" aria-label="' . esc_attr__( 'Page', 'twentytwenty' ) . '"><span class="label">' . __( 'Pages:', 'twentytwenty' ) . '</span>',
-				'after'  => '</nav>',
+				'before'      => '<nav class="post-nav-links bg-light-background" aria-label="' . esc_attr__( 'Page', 'twentytwenty' ) . '"><span class="label">' . __( 'Pages:', 'twentytwenty' ) . '</span>',
+				'after'       => '</nav>',
+				'link_before' => '<span class="page-number">',
+				'link_after'  => '</span>',
 			)
 		);
 


### PR DESCRIPTION
Adds a span to the page numbers of wp_link_pages, so that the numbers are aligned.
The span also has the class _page-number_ added for future changes.

Solves #125

4.9:
![pages49](https://user-images.githubusercontent.com/7422055/65986458-2fc89000-e484-11e9-82d2-24435f77c2c8.png)
