### PR TITLE
RSS Widget: hide full link instead of just the related image

### DIFF
--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1186,6 +1186,10 @@ button.toggle {
 	flex-shrink: 0;
 }
 
+.search-form .search-submit:hover {
+	text-decoration: none;
+}
+
 
 /* Social Icons ------------------------------ */
 
@@ -1646,6 +1650,7 @@ body:not(.enable-search-modal) .site-logo img {
 }
 
 .toggle-icon {
+	display: block;
 	overflow: hidden;
 }
 
@@ -1655,7 +1660,8 @@ body:not(.enable-search-modal) .site-logo img {
 	font-weight: 600;
 	position: absolute;
 	top: calc(100% + 0.5rem);
-	width: 10rem;
+	width: auto;
+	white-space: nowrap;
 	word-break: break-all;
 }
 
@@ -2312,6 +2318,7 @@ button.search-untoggle {
 
 .cover-header-inner-wrapper {
 	display: flex;
+	position: relative;
 	flex-direction: column;
 	justify-content: flex-end;
 	width: 100%;
@@ -4192,6 +4199,10 @@ div.comment:first-of-type {
 
 .widget_rss a {
 	text-decoration: none;
+}
+
+.widget_rss a.rsswidget:first-of-type {
+	display: none;
 }
 
 .widget_rss a:focus,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4189,7 +4189,7 @@ div.comment:first-of-type {
 
 /* Widget: RSS ------------------------------- */
 
-.widget_rss .rss-widget-icon {
+.widget_rss a.rsswidget:first-of-type {
 	display: none;
 }
 
@@ -4199,10 +4199,6 @@ div.comment:first-of-type {
 
 .widget_rss a {
 	text-decoration: none;
-}
-
-.widget_rss a.rsswidget:first-of-type {
-	display: none;
 }
 
 .widget_rss a:focus,

--- a/style.css
+++ b/style.css
@@ -4191,7 +4191,7 @@ div.comment:first-of-type {
 
 /* Widget: RSS ------------------------------- */
 
-.widget_rss .rss-widget-icon {
+.widget_rss a.rsswidget:first-of-type {
 	display: none;
 }
 
@@ -4201,10 +4201,6 @@ div.comment:first-of-type {
 
 .widget_rss a {
 	text-decoration: none;
-}
-
-.widget_rss a.rsswidget:first-of-type {
-	display: none;
 }
 
 .widget_rss a:focus,

--- a/style.css
+++ b/style.css
@@ -4203,6 +4203,10 @@ div.comment:first-of-type {
 	text-decoration: none;
 }
 
+.widget_rss a.rsswidget:first-of-type {
+	display: none;
+}
+
 .widget_rss a:focus,
 .widget_rss a:hover {
 	text-decoration: underline;


### PR DESCRIPTION
Instead of removing the RSS image, it would be better to remove the full link. Without that, the link will be vocalized as an empty link by assistive technologies. 

Worth noting I had to use `:first-of-type` pseudo selector since there is no specific class on this element.

Cheers,
Jb