### PR TITLE
Fix - Unnecessary use of escaping functions

### DIFF
--- a/classes/class-twentytwenty-customize.php
+++ b/classes/class-twentytwenty-customize.php
@@ -136,7 +136,7 @@ if ( ! class_exists( 'TwentyTwenty_Customize' ) ) {
 					),
 					'type'              => 'theme_mod',
 					'transport'         => 'postMessage',
-					'sanitize_callback' => array( 'TwentyTwenty_Customize', 'sanitize_accent_accessible_colors' ),
+					'sanitize_callback' => array( __CLASS__, 'sanitize_accent_accessible_colors' ),
 				)
 			);
 

--- a/classes/class-twentytwenty-walker-comment.php
+++ b/classes/class-twentytwenty-walker-comment.php
@@ -33,7 +33,7 @@ if ( ! class_exists( 'TwentyTwenty_Walker_Comment' ) ) {
 			$tag = ( 'div' === $args['style'] ) ? 'div' : 'li';
 
 			?>
-			<<?php echo esc_html( $tag ); ?> id="comment-<?php comment_ID(); ?>" <?php comment_class( $this->has_children ? 'parent' : '', $comment ); ?>>
+			<<?php echo $tag; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static output ?> id="comment-<?php comment_ID(); ?>" <?php comment_class( $this->has_children ? 'parent' : '', $comment ); ?>>
 				<article id="div-comment-<?php comment_ID(); ?>" class="comment-body">
 					<footer class="comment-meta">
 						<div class="comment-author vcard">

--- a/comments.php
+++ b/comments.php
@@ -47,7 +47,7 @@ if ( $comments ) {
 							'twentytwenty'
 						),
 						number_format_i18n( $comments_number ),
-						get_the_title()
+						esc_html( get_the_title() )
 					)
 				);
 			}
@@ -80,6 +80,7 @@ if ( $comments ) {
 			);
 
 			if ( $comment_pagination ) {
+				$pagination_classes = '';
 
 				// If we're only showing the "Next" link, add a class indicating so.
 				if ( strpos( $comment_pagination, 'prev page-numbers' ) === false ) {
@@ -89,7 +90,7 @@ if ( $comments ) {
 				}
 				?>
 
-				<nav class="comments-pagination pagination<?php echo esc_attr( $pagination_classes ); ?>" aria-label="<?php esc_attr_e( 'Comments', 'twentytwenty' ); ?>">
+				<nav class="comments-pagination pagination<?php echo $pagination_classes; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static output ?>" aria-label="<?php esc_attr_e( 'Comments', 'twentytwenty' ); ?>">
 					<?php echo wp_kses_post( $comment_pagination ); ?>
 				</nav>
 

--- a/functions.php
+++ b/functions.php
@@ -499,7 +499,7 @@ function twentytwenty_read_more_tag() {
 		'<a href="%1$s" class="more-link faux-button">%2$s <span class="screen-reader-text">"%3$s"</span></a>',
 		esc_url( get_permalink( get_the_ID() ) ),
 		esc_html__( 'Continue reading', 'twentytwenty' ),
-		get_the_title( get_the_ID() )
+		esc_html( get_the_title( get_the_ID() ) )
 	);
 }
 add_filter( 'the_content_more_link', 'twentytwenty_read_more_tag' );

--- a/header.php
+++ b/header.php
@@ -128,7 +128,7 @@
 					}
 					?>
 
-					<div class="header-toggles hide-no-js<?php echo esc_attr( $header_toggles_classes ); ?>">
+					<div class="header-toggles hide-no-js<?php echo $header_toggles_classes; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static output ?>">
 
 						<?php
 						$nav_toggle_wrapper_classes = '';
@@ -139,7 +139,7 @@
 						}
 						?>
 
-						<div class="toggle-wrapper nav-toggle-wrapper<?php echo esc_attr( $nav_toggle_wrapper_classes ); ?>">
+						<div class="toggle-wrapper nav-toggle-wrapper<?php echo $nav_toggle_wrapper_classes; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static output ?>">
 
 							<button class="toggle nav-toggle" data-toggle-target=".menu-modal" data-toggle-screen-lock="true" data-toggle-body-class="showing-menu-modal" aria-expanded="false" data-set-focus=".close-nav-toggle">
 								<span class="toggle-inner">

--- a/template-parts/content-cover.php
+++ b/template-parts/content-cover.php
@@ -44,7 +44,7 @@
 	$color_overlay_classes .= ' opacity-' . $color_overlay_opacity;
 	?>
 
-	<div class="cover-header <?php echo esc_attr( $cover_header_classes ); ?>"<?php echo $cover_header_style; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We need to double check this, but for now, we want to pass PHPCS ;) ?>>
+	<div class="cover-header <?php echo $cover_header_classes; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static output ?>"<?php echo $cover_header_style; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We need to double check this, but for now, we want to pass PHPCS ;) ?>>
 		<div class="cover-header-inner-wrapper screen-height">
 			<div class="cover-header-inner">
 				<div class="cover-color-overlay color-accent<?php echo esc_attr( $color_overlay_classes ); ?>"<?php echo $color_overlay_style; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We need to double check this, but for now, we want to pass PHPCS ;) ?>></div>

--- a/template-parts/entry-author-bio.php
+++ b/template-parts/entry-author-bio.php
@@ -17,7 +17,7 @@ if ( (bool) get_the_author_meta( 'description' ) ) : ?>
 				<?php
 				printf(
 					/* Translators: %s: post author */
-					esc_html__( 'By %s', 'twentytwenty' ),
+					__( 'By %s', 'twentytwenty' ),
 					esc_html( get_the_author() )
 				);
 				?>

--- a/template-parts/entry-author-bio.php
+++ b/template-parts/entry-author-bio.php
@@ -17,8 +17,8 @@ if ( (bool) get_the_author_meta( 'description' ) ) : ?>
 				<?php
 				printf(
 					/* Translators: %s: post author */
-					__( 'By %s', 'twentytwenty' ),
-					esc_html( get_the_author() )
+					__( 'By %s', 'twentytwenty' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- core trusts translations
+					esc_html( get_the_author() ) 
 				);
 				?>
 			</span>

--- a/template-parts/entry-header.php
+++ b/template-parts/entry-header.php
@@ -59,7 +59,7 @@ if ( is_singular() ) {
 		if ( has_excerpt() && is_singular() ) {
 			?>
 
-			<div class="intro-text section-inner max-percentage<?php echo esc_attr( $intro_text_width ); ?>">
+			<div class="intro-text section-inner max-percentage<?php echo $intro_text_width; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static output ?>">
 				<?php the_excerpt(); ?>
 			</div>
 

--- a/template-parts/featured-image.php
+++ b/template-parts/featured-image.php
@@ -19,7 +19,7 @@ if ( has_post_thumbnail() && ! post_password_required() ) {
 
 	<figure class="featured-media">
 
-		<div class="featured-media-inner section-inner<?php echo esc_attr( $featured_media_inner_classes ); ?>">
+		<div class="featured-media-inner section-inner<?php echo $featured_media_inner_classes; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static output ?>">
 
 			<?php
 			the_post_thumbnail();

--- a/template-parts/footer-menus-widgets.php
+++ b/template-parts/footer-menus-widgets.php
@@ -33,7 +33,7 @@ if ( $has_footer_menu || $has_social_menu || $has_sidebar_1 || $has_sidebar_2 ) 
 
 			if ( $has_footer_menu || $has_social_menu ) {
 				?>
-				<div class="footer-top<?php echo esc_attr( $footer_top_classes ); ?>">
+				<div class="footer-top<?php echo $footer_top_classes; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static output ?>">
 					<?php if ( $has_footer_menu ) { ?>
 
 						<nav aria-label="<?php esc_attr_e( 'Footer', 'twentytwenty' ); ?>" role="navigation">
@@ -56,7 +56,7 @@ if ( $has_footer_menu || $has_social_menu || $has_sidebar_1 || $has_sidebar_2 ) 
 					<?php } ?>
 					<?php if ( $has_social_menu ) { ?>
 
-						<div class="<?php echo esc_attr( $footer_social_wrapper_class ); ?>">
+						<div class="<?php echo $footer_social_wrapper_class; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static output ?>">
 
 							<nav aria-label="<?php esc_attr_e( 'Social links', 'twentytwenty' ); ?>">
 

--- a/template-parts/modal-menu.php
+++ b/template-parts/modal-menu.php
@@ -45,7 +45,7 @@
 
 					?>
 
-					<nav class="expanded-menu<?php echo esc_attr( $expanded_nav_classes ); ?>" aria-label="<?php esc_attr_e( 'Expanded', 'twentytwenty' ); ?>">
+					<nav class="expanded-menu<?php echo $expanded_nav_classes; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static output ?>" aria-label="<?php esc_attr_e( 'Expanded', 'twentytwenty' ); ?>">
 
 						<ul class="modal-menu reset-list-style">
 							<?php

--- a/template-parts/navigation.php
+++ b/template-parts/navigation.php
@@ -22,7 +22,7 @@ if ( $next_post || $prev_post ) {
 
 	?>
 
-	<nav class="pagination-single section-inner<?php echo esc_attr( $pagination_classes ); ?>" aria-label="<?php esc_attr_e( 'Post', 'twentytwenty' ); ?>">
+	<nav class="pagination-single section-inner<?php echo $pagination_classes; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static output ?>" aria-label="<?php esc_attr_e( 'Post', 'twentytwenty' ); ?>">
 
 		<hr class="styled-separator is-style-wide" aria-hidden="true" />
 


### PR DESCRIPTION
Fix for #147 

I also wrapped a few `get_the_title()` instances with `esc_html`, in places where adding `em` or `strong` tags would look bad (like the read more link)`

@ianbelanger79 I think I got them all 😄 