### PR TITLE
PHPCS: i18n functions are considered safe for core translations.

### DIFF
--- a/404.php
+++ b/404.php
@@ -14,9 +14,9 @@ get_header();
 
 	<div class="section-inner thin error404-content">
 
-		<h1 class="entry-title"><?php _e( 'Page Not Found', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></h1>
+		<h1 class="entry-title"><?php _e( 'Page Not Found', 'twentytwenty' ); ?></h1>
 
-		<div class="intro-text"><p><?php _e( 'The page you were looking for could not be found. It might have been removed, renamed, or did not exist in the first place.', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></p></div>
+		<div class="intro-text"><p><?php _e( 'The page you were looking for could not be found. It might have been removed, renamed, or did not exist in the first place.', 'twentytwenty' ); ?></p></div>
 
 		<?php
 		get_search_form(

--- a/classes/class-twentytwenty-customize.php
+++ b/classes/class-twentytwenty-customize.php
@@ -90,7 +90,7 @@ if ( ! class_exists( 'TwentyTwenty_Customize' ) ) {
 					$wp_customize,
 					'header_footer_background_color',
 					array(
-						'label'   => esc_html__( 'Header & Footer Background Color', 'twentytwenty' ),
+						'label'   => __( 'Header &amp; Footer Background Color', 'twentytwenty' ),
 						'section' => 'colors',
 					)
 				)

--- a/classes/class-twentytwenty-walker-comment.php
+++ b/classes/class-twentytwenty-walker-comment.php
@@ -50,8 +50,11 @@ if ( ! class_exists( 'TwentyTwenty_Walker_Comment' ) ) {
 								}
 							}
 
-							/* Translators: '%1$s = comment author name */
-							printf( '<span class="fn">%1$s</span><span class="screen-reader-text says">%2$s</span>', esc_html( $comment_author ), __( 'says:', 'twentytwenty' ) ); // phpcs:ignore
+							printf(
+								'<span class="fn">%1$s</span><span class="screen-reader-text says">%2$s</span>',
+								esc_html( $comment_author ),
+								__( 'says:', 'twentytwenty' )
+							);
 
 							if ( ! empty( $comment_author_url ) ) {
 								echo '</a>';
@@ -71,7 +74,7 @@ if ( ! class_exists( 'TwentyTwenty_Walker_Comment' ) ) {
 							</a>
 							<?php
 							if ( get_edit_comment_link() ) {
-								echo ' &bull; <a class="comment-edit-link" href="' . esc_url( get_edit_comment_link() ) . '">' . __( 'Edit', 'twentytwenty' ) . '</a>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- core trusts translations
+								echo ' &bull; <a class="comment-edit-link" href="' . esc_url( get_edit_comment_link() ) . '">' . __( 'Edit', 'twentytwenty' ) . '</a>';
 							}
 							?>
 						</div><!-- .comment-metadata -->
@@ -86,7 +89,7 @@ if ( ! class_exists( 'TwentyTwenty_Walker_Comment' ) ) {
 
 						if ( '0' === $comment->comment_approved ) {
 							?>
-							<p class="comment-awaiting-moderation"><?php _e( 'Your comment is awaiting moderation.', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></p>
+							<p class="comment-awaiting-moderation"><?php _e( 'Your comment is awaiting moderation.', 'twentytwenty' ); ?></p>
 							<?php
 						}
 
@@ -121,7 +124,7 @@ if ( ! class_exists( 'TwentyTwenty_Walker_Comment' ) ) {
 								echo $comment_reply_link; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped --Link is escaped in https://developer.wordpress.org/reference/functions/get_comment_reply_link/
 							}
 							if ( $by_post_author ) {
-								echo '<span class="by-post-author">' . __( 'By Post Author', 'twentytwenty' ) . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- core trusts translations
+								echo '<span class="by-post-author">' . __( 'By Post Author', 'twentytwenty' ) . '</span>';
 							}
 							?>
 

--- a/comments.php
+++ b/comments.php
@@ -31,24 +31,22 @@ if ( $comments ) {
 			<h2 class="comment-reply-title">
 			<?php
 			if ( ! have_comments() ) {
-				esc_html_e( 'Leave a comment', 'twentytwenty' );
+				_e( 'Leave a comment', 'twentytwenty' );
 			} elseif ( '1' === $comments_number ) {
 				/* translators: %s: post title */
-				printf( esc_html_x( 'One reply on &ldquo;%s&rdquo;', 'comments title', 'twentytwenty' ), esc_html( get_the_title() ) );
+				printf( _x( 'One reply on &ldquo;%s&rdquo;', 'comments title', 'twentytwenty' ), esc_html( get_the_title() ) );
 			} else {
-				echo esc_html(
-					sprintf(
-						/* translators: 1: number of comments, 2: post title */
-						_nx(
-							'%1$s reply on &ldquo;%2$s&rdquo;',
-							'%1$s replies on &ldquo;%2$s&rdquo;',
-							$comments_number,
-							'comments title',
-							'twentytwenty'
-						),
-						number_format_i18n( $comments_number ),
-						esc_html( get_the_title() )
-					)
+				echo sprintf(
+					/* translators: 1: number of comments, 2: post title */
+					_nx(
+						'%1$s reply on &ldquo;%2$s&rdquo;',
+						'%1$s replies on &ldquo;%2$s&rdquo;',
+						$comments_number,
+						'comments title',
+						'twentytwenty'
+					),
+					number_format_i18n( $comments_number ),
+					esc_html( get_the_title() )
 				);
 			}
 
@@ -60,7 +58,6 @@ if ( $comments ) {
 		<div class="comments-inner section-inner thin max-percentage">
 
 			<?php
-
 			wp_list_comments(
 				array(
 					'walker'      => new TwentyTwenty_Walker_Comment(),

--- a/comments.php
+++ b/comments.php
@@ -127,7 +127,7 @@ if ( comments_open() || pings_open() ) {
 
 	<div class="comment-respond" id="respond">
 
-		<p class="comments-closed"><?php _e( 'Comments are closed.', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></p>
+		<p class="comments-closed"><?php _e( 'Comments are closed.', 'twentytwenty' ); ?></p>
 
 	</div><!-- #respond -->
 

--- a/footer.php
+++ b/footer.php
@@ -32,9 +32,7 @@
 
 						<p class="powered-by-wordpress">
 							<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentytwenty' ) ); ?>">
-								<?php
-								_e( 'Powered by WordPress', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations
-								?>
+								<?php _e( 'Powered by WordPress', 'twentytwenty' ); ?>
 							</a>
 						</p><!-- .powered-by-wordpress -->
 

--- a/footer.php
+++ b/footer.php
@@ -20,11 +20,9 @@
 
 						<p class="footer-copyright">&copy;
 							<?php
-							echo esc_html(
-								date_i18n(
-									/* translators: Copyright date format, see https://secure.php.net/date */
-									_x( 'Y', 'copyright date format', 'twentytwenty' )
-								)
+							echo date_i18n(
+								/* translators: Copyright date format, see https://secure.php.net/date */
+								_x( 'Y', 'copyright date format', 'twentytwenty' )
 							);
 							?>
 							<a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php echo bloginfo( 'name' ); ?></a>
@@ -42,13 +40,13 @@
 						<span class="to-the-top-long">
 							<?php
 							/* translators: %s: HTML character for up arrow */
-							printf( esc_html( __( 'To the top %s', 'twentytwenty' ) ), '<span class="arrow">&uarr;</span>' );
+							printf( __( 'To the top %s', 'twentytwenty' ), '<span class="arrow">&uarr;</span>' );
 							?>
 						</span><!-- .to-the-top-long -->
 						<span class="to-the-top-short">
 							<?php
 							/* translators: %s: HTML character for up arrow */
-							printf( esc_html( __( 'Up %s', 'twentytwenty' ) ), '<span class="arrow">&uarr;</span>' );
+							printf( __( 'Up %s', 'twentytwenty' ), '<span class="arrow">&uarr;</span>' );
 							?>
 						</span><!-- .to-the-top-short -->
 					</a><!-- .to-the-top -->

--- a/functions.php
+++ b/functions.php
@@ -284,7 +284,7 @@ if ( ! function_exists( 'wp_body_open' ) ) {
  * Include a skip to content link at the top of the page so that users can bypass the menu.
  */
 function twentytwenty_skip_link() {
-	echo '<a class="skip-link screen-reader-text" href="#site-content">' . __( 'Skip to the content', 'twentytwenty' ) . '</a>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- core trusts translations
+	echo '<a class="skip-link screen-reader-text" href="#site-content">' . __( 'Skip to the content', 'twentytwenty' ) . '</a>';
 }
 
 add_action( 'wp_body_open', 'twentytwenty_skip_link', 5 );

--- a/functions.php
+++ b/functions.php
@@ -398,17 +398,17 @@ function twentytwenty_block_editor_settings() {
 	// Block Editor Palette.
 	$editor_color_palette = array(
 		array(
-			'name'  => esc_html__( 'Accent Color', 'twentytwenty' ),
+			'name'  => __( 'Accent Color', 'twentytwenty' ),
 			'slug'  => 'accent',
 			'color' => twentytwenty_get_color_for_area( 'content', 'accent' ),
 		),
 		array(
-			'name'  => esc_html__( 'Secondary', 'twentytwenty' ),
+			'name'  => __( 'Secondary', 'twentytwenty' ),
 			'slug'  => 'secondary',
 			'color' => twentytwenty_get_color_for_area( 'content', 'secondary' ),
 		),
 		array(
-			'name'  => esc_html__( 'Subtle Background', 'twentytwenty' ),
+			'name'  => __( 'Subtle Background', 'twentytwenty' ),
 			'slug'  => 'subtle-background',
 			'color' => twentytwenty_get_color_for_area( 'content', 'borders' ),
 		),
@@ -480,7 +480,7 @@ function twentytwenty_read_more_tag() {
 	return sprintf(
 		'<a href="%1$s" class="more-link faux-button">%2$s <span class="screen-reader-text">"%3$s"</span></a>',
 		esc_url( get_permalink( get_the_ID() ) ),
-		esc_html__( 'Continue reading', 'twentytwenty' ),
+		__( 'Continue reading', 'twentytwenty' ),
 		esc_html( get_the_title( get_the_ID() ) )
 	);
 }

--- a/header.php
+++ b/header.php
@@ -50,7 +50,7 @@
 								<span class="toggle-icon">
 									<?php twentytwenty_the_theme_svg( 'search' ); ?>
 								</span>
-								<span class="toggle-text"><?php _e( 'Search', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></span>
+								<span class="toggle-text"><?php _e( 'Search', 'twentytwenty' ); ?></span>
 							</span>
 						</button><!-- .search-toggle -->
 
@@ -73,7 +73,7 @@
 							<span class="toggle-icon">
 								<?php twentytwenty_the_theme_svg( 'ellipsis' ); ?>
 							</span>
-							<span class="toggle-text"><?php _e( 'Menu', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></span>
+							<span class="toggle-text"><?php _e( 'Menu', 'twentytwenty' ); ?></span>
 						</span>
 					</button><!-- .nav-toggle -->
 
@@ -143,7 +143,7 @@
 
 							<button class="toggle nav-toggle desktop-nav-toggle" data-toggle-target=".menu-modal" data-toggle-body-class="showing-menu-modal" aria-expanded="false" data-set-focus=".close-nav-toggle">
 								<span class="toggle-inner">
-									<span class="toggle-text"><?php _e( 'Menu', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></span>
+									<span class="toggle-text"><?php _e( 'Menu', 'twentytwenty' ); ?></span>
 									<span class="toggle-icon">
 										<?php twentytwenty_the_theme_svg( 'ellipsis' ); ?>
 									</span>
@@ -161,7 +161,7 @@
 								<button class="toggle search-toggle desktop-search-toggle" data-toggle-target=".search-modal" data-toggle-body-class="showing-search-modal" data-set-focus=".search-modal .search-field" aria-expanded="false">
 									<span class="toggle-inner">
 										<?php twentytwenty_the_theme_svg( 'search' ); ?>
-										<span class="toggle-text"><?php _e( 'Search', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></span>
+										<span class="toggle-text"><?php _e( 'Search', 'twentytwenty' ); ?></span>
 									</span>
 								</button><!-- .search-toggle -->
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -291,14 +291,14 @@ function twentytwenty_get_post_meta( $post_id = null, $location = 'single-top' )
 					?>
 					<li class="post-author meta-wrapper">
 						<span class="meta-icon">
-							<span class="screen-reader-text"><?php _e( 'Post author', 'twentytwenty' );// phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></span>
+							<span class="screen-reader-text"><?php _e( 'Post author', 'twentytwenty' ); ?></span>
 							<?php twentytwenty_the_theme_svg( 'user' ); ?>
 						</span>
 						<span class="meta-text">
 							<?php
 							printf(
 								/* translators: %s: Author name */
-								__( 'By %s', 'twentytwenty' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- core trusts translations
+								__( 'By %s', 'twentytwenty' ),
 								'<a href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author_meta( 'display_name' ) ) . '</a>'
 							);
 							?>
@@ -316,7 +316,7 @@ function twentytwenty_get_post_meta( $post_id = null, $location = 'single-top' )
 					<li class="post-date">
 						<a class="meta-wrapper" href="<?php the_permalink(); ?>">
 							<span class="meta-icon">
-								<span class="screen-reader-text"><?php _e( 'Post date', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></span>
+								<span class="screen-reader-text"><?php _e( 'Post date', 'twentytwenty' ); ?></span>
 								<?php twentytwenty_the_theme_svg( 'calendar' ); ?>
 							</span>
 							<span class="meta-text">
@@ -335,11 +335,11 @@ function twentytwenty_get_post_meta( $post_id = null, $location = 'single-top' )
 					?>
 					<li class="post-categories meta-wrapper">
 						<span class="meta-icon">
-							<span class="screen-reader-text"><?php _e( 'Categories', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></span>
+							<span class="screen-reader-text"><?php _e( 'Categories', 'twentytwenty' ); ?></span>
 							<?php twentytwenty_the_theme_svg( 'folder' ); ?>
 						</span>
 						<span class="meta-text">
-							<?php _e( 'In', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?> <?php the_category( ', ' ); ?>
+							<?php _e( 'In', 'twentytwenty' ); ?> <?php the_category( ', ' ); ?>
 						</span>
 					</li>
 					<?php
@@ -353,7 +353,7 @@ function twentytwenty_get_post_meta( $post_id = null, $location = 'single-top' )
 					?>
 					<li class="post-tags meta-wrapper">
 						<span class="meta-icon">
-							<span class="screen-reader-text"><?php _e( 'Tags', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></span>
+							<span class="screen-reader-text"><?php _e( 'Tags', 'twentytwenty' ); ?></span>
 							<?php twentytwenty_the_theme_svg( 'tag' ); ?>
 						</span>
 						<span class="meta-text">
@@ -391,7 +391,7 @@ function twentytwenty_get_post_meta( $post_id = null, $location = 'single-top' )
 							<?php twentytwenty_the_theme_svg( 'bookmark' ); ?>
 						</span>
 						<span class="meta-text">
-							<?php _e( 'Sticky post', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?>
+							<?php _e( 'Sticky post', 'twentytwenty' ); ?>
 						</span>
 					</li>
 					<?php

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -34,24 +34,43 @@
     </properties>
   </rule>
 
-	<!-- Allow multiple parameters on one line for multi-line function calls. -->
-	<rule ref="PEAR.Functions.FunctionCallSignature">
+  <!-- Allow multiple parameters on one line for multi-line function calls. -->
+  <rule ref="PEAR.Functions.FunctionCallSignature">
     <properties>
        <property name="allowMultipleArguments" value="true" />
     </properties>
-	</rule>
+  </rule>
 
-	<!-- Improve code readablilty by allowing the artguments after function call. -->
+  <!-- Improve code readablilty by allowing the artguments after function call. -->
   <rule ref="PEAR.Functions.FunctionCallSignature">
-  	<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
-  	<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine"/>
-	</rule>
+    <exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
+    <exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine"/>
+  </rule>
 
   <!-- Check valid textdomain. -->
   <rule ref="WordPress.WP.I18n">
     <properties>
       <property name="text_domain" type="array">
         <element value="twentytwenty"/>
+      </property>
+    </properties>
+  </rule>
+
+  <rule ref="WordPress-Extra">
+    <!-- _e() and _ex() are considered safe for core translations. -->
+    <exclude name="WordPress.Security.EscapeOutput.UnsafePrintingFunction"/>
+  </rule>
+
+  <rule ref="WordPress.Security.EscapeOutput">
+    <properties>
+      <property name="customAutoEscapedFunctions" type="array">
+        <!-- i18n functions are considered safe for core translations. -->
+        <element value="__"/>
+        <element value="_x"/>
+        <element value="_n"/>
+        <element value="_nx"/>
+        <element value="number_format_i18n"/>
+        <element value="date_i18n"/>
       </property>
     </properties>
   </rule>

--- a/template-parts/content-cover.php
+++ b/template-parts/content-cover.php
@@ -85,7 +85,7 @@
 
 									<a href="#post-inner" class="to-the-content fill-children-current-color">
 										<?php twentytwenty_the_theme_svg( 'arrow-down' ); ?>
-										<div class="screen-reader-text"><?php _e( 'Scroll Down', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></div>
+										<div class="screen-reader-text"><?php _e( 'Scroll Down', 'twentytwenty' ); ?></div>
 									</a><!-- .to-the-content -->
 
 								</div><!-- .to-the-content-wrapper -->

--- a/template-parts/content-cover.php
+++ b/template-parts/content-cover.php
@@ -67,7 +67,7 @@
 								?>
 
 								<div class="entry-categories">
-									<span class="screen-reader-text"><?php esc_html_e( 'Categories', 'twentytwenty' ); ?></span>
+									<span class="screen-reader-text"><?php _e( 'Categories', 'twentytwenty' ); ?></span>
 									<div class="entry-categories-inner">
 										<?php the_category( ' ' ); ?>
 									</div><!-- .entry-categories-inner -->

--- a/template-parts/entry-author-bio.php
+++ b/template-parts/entry-author-bio.php
@@ -26,7 +26,7 @@ if ( (bool) get_the_author_meta( 'description' ) ) : ?>
 		<p class="author-description">
 			<?php the_author_meta( 'description' ); ?>
 			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
-				<?php esc_html_e( 'View Archive &rarr;', 'twentytwenty' ); ?>
+				<?php _e( 'View Archive &rarr;', 'twentytwenty' ); ?>
 			</a>
 		</p><!-- .author-description -->
 </div><!-- .author-bio -->

--- a/template-parts/entry-author-bio.php
+++ b/template-parts/entry-author-bio.php
@@ -17,7 +17,7 @@ if ( (bool) get_the_author_meta( 'description' ) ) : ?>
 				<?php
 				printf(
 					/* translators: %s: Author name */
-					__( 'By %s', 'twentytwenty' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- core trusts translations
+					__( 'By %s', 'twentytwenty' ),
 					esc_html( get_the_author() )
 				);
 				?>

--- a/template-parts/entry-header.php
+++ b/template-parts/entry-header.php
@@ -33,7 +33,7 @@ if ( is_singular() ) {
 			?>
 
 			<div class="entry-categories">
-				<span class="screen-reader-text"><?php esc_html_e( 'Categories', 'twentytwenty' ); ?></span>
+				<span class="screen-reader-text"><?php _e( 'Categories', 'twentytwenty' ); ?></span>
 				<div class="entry-categories-inner">
 					<?php the_category( ' ' ); ?>
 				</div><!-- .entry-categories-inner -->

--- a/template-parts/modal-menu.php
+++ b/template-parts/modal-menu.php
@@ -18,7 +18,7 @@
 			<div class="menu-top">
 
 				<button class="toggle close-nav-toggle fill-children-current-color" data-toggle-target=".menu-modal" data-toggle-body-class="showing-menu-modal" aria-expanded="false" data-set-focus=".menu-modal">
-					<span class="toggle-text"><?php esc_html_e( 'Close Menu', 'twentytwenty' ); ?></span>
+					<span class="toggle-text"><?php _e( 'Close Menu', 'twentytwenty' ); ?></span>
 					<?php twentytwenty_the_theme_svg( 'cross' ); ?>
 				</button><!-- .nav-toggle -->
 
@@ -64,10 +64,10 @@
 
 					</nav>
 
-					<?php 
+					<?php
 				}
-				
-				if ( 'expanded' !== $mobile_menu_location ) { 
+
+				if ( 'expanded' !== $mobile_menu_location ) {
 					?>
 
 					<nav class="mobile-menu" aria-label="<?php esc_attr_e( 'Mobile', 'twentytwenty' ); ?>" role="navigation">
@@ -104,7 +104,7 @@
 
 					</nav>
 
-					<?php 
+					<?php
 				}
 				?>
 

--- a/template-parts/modal-search.php
+++ b/template-parts/modal-search.php
@@ -23,7 +23,7 @@
 			?>
 
 			<button class="toggle search-untoggle fill-children-current-color" data-toggle-target=".search-modal" data-toggle-body-class="showing-search-modal" data-set-focus=".search-modal .search-field">
-				<span class="screen-reader-text"><?php _e( 'Close search', 'twentytwenty' ); // phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction -- core trusts translations ?></span>
+				<span class="screen-reader-text"><?php _e( 'Close search', 'twentytwenty' ); ?></span>
 				<?php twentytwenty_the_theme_svg( 'cross' ); ?>
 			</button><!-- .search-toggle -->
 


### PR DESCRIPTION
This adjusts the PHPCS config to align with WordPress core. It also allows us to remove the `// phpcs:ignore: WordPress.Security.EscapeOutput.OutputNotEscaped -- core trusts translations` comments and the use of escaping functions around strings.