### PR TITLE
Removed underline on mouseover of Post Comment button

### DIFF
--- a/style.css
+++ b/style.css
@@ -3889,6 +3889,10 @@ div.comment:first-of-type {
 	display: block;
 }
 
+.comment-respond #submit:hover {
+	text-decoration: none;
+}
+
 .comment-respond .comments-closed {
 	text-align: center;
 }


### PR DESCRIPTION
Removed underline from Post Comment button, so that all button style will be consistent across the site.