### PR TITLE
Featured Images: do not display on posts using the Image Post Format

### DIFF
--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -19,7 +19,10 @@
 
 	get_template_part( 'template-parts/entry-header' );
 
-	if ( ! is_search() ) {
+	if (
+		! is_search()
+		&& ! ( is_singular() && has_post_format( 'image' ) )
+	) {
 		get_template_part( 'template-parts/featured-image' );
 	}
 


### PR DESCRIPTION
Although Twenty Twenty itself does not declare support for Post Formats, one may have existing posts using Post Formats.

If that's the case, when viewing single posts you will see a quite large featured image followed by the post content, including an image that is very likely to be the same as the featured image. This PR avoids displaying the featured image in such scenarios.

I feel this is an important addition to Twenty Twenty as the Featured Images (especially in a portrait orientation) can take quite a lot of space.
I've limited that change to the single post view, as folks will typically not see the post image on index views (they will see an excerpt instead, which does not show the post image).

WordPress.org username: `jeherve`