### PR TITLE
Merge isset() and empty()

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -16,7 +16,7 @@
  * one was passed to get_search_form() in the args array.
  */
 $unique_id  = wp_unique_id( 'search-form-' );
-$aria_label = ( isset( $args['label'] ) && ! empty( $args['label'] ) ) ? 'aria-label="' . esc_attr( $args['label'] ) . '"' : '';
+$aria_label = ! empty( $args['label'] ) ? 'aria-label="' . esc_attr( $args['label'] ) . '"' : '';
 ?>
 <form role="search" <?php echo $aria_label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above. ?> method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 	<label for="<?php echo esc_attr( $unique_id ); ?>">


### PR DESCRIPTION
There's no need to first check if the key is set, `empty()` already covers this and doesn't throw a warning.