### PR TITLE
Add licensing information for Twenty Seventeen and Twenty Nineteen

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,48 +36,48 @@ License: Creative Commons Zero (CC0), https://creativecommons.org/publicdomain/z
 URL: https://pxhere.com/en/photo/18153  
 
 Inter Font  
-Copyright (c) 2016-2019 The Inter Project Authors (me@rsms.me)
+Copyright (c) 2016-2019 The Inter Project Authors (me@rsms.me)  
 License: SIL Open Font License, 1.1, https://opensource.org/licenses/OFL-1.1  
 Source: https://rsms.me/inter/  
 
 Bespoke Icons Created For Twenty Twenty  
 License: Creative Commons Zero (CC0), https://creativecommons.org/publicdomain/zero/1.0/  
 List of bespoke icons:  
-- Search icon
-- Menu icon
+- Search icon  
+- Menu icon  
 
 Feather Icons  
 Copyright (c) 2013-2017 Cole Bemis  
 License: MIT License, https://opensource.org/licenses/MIT  
-Source: https://feathericons.com
-Used for post meta icons, and the link icon in the social menu.
+Source: https://feathericons.com  
+Used for post meta icons, and the link icon in the social menu.  
 
-Socicon Icons
-License: SIL Open Font License, 1.1, https://opensource.org/licenses/OFL-1.1
-Source: https://www.socicon.com
-Used for all social menu icons except the link icon.
+Socicon Icons  
+License: SIL Open Font License, 1.1, https://opensource.org/licenses/OFL-1.1  
+Source: https://www.socicon.com  
+Used for all social menu icons except the link icon.  
 
-Code from Twenty Nineteen
-Copyright (c) 2018 WordPress.org
-License: GPLv2
-Source: https://wordpress.org/themes/twentynineteen/
-Included as part of the following classes and functions:
-- TwentyTwenty_SVG_Icons
-- twentytwenty_the_theme_svg()
-- twentytwenty_get_theme_svg()
-- twentytwenty_nav_menu_social_icons()
+Code from Twenty Nineteen  
+Copyright (c) 2018 WordPress.org  
+License: GPLv2  
+Source: https://wordpress.org/themes/twentynineteen/  
+Included as part of the following classes and functions:  
+- TwentyTwenty_SVG_Icons  
+- twentytwenty_the_theme_svg()  
+- twentytwenty_get_theme_svg()  
+- twentytwenty_nav_menu_social_icons()  
 
-Code from Twenty Seventeen
-Copyright (c) 2016 WordPress.org
-License: GPLv2
-Source: https://wordpress.org/themes/twentyseventeen/
-Included as part of the following classes and functions:
-- twentytwenty_unique_id()
+Code from Twenty Seventeen  
+Copyright (c) 2016 WordPress.org  
+License: GPLv2  
+Source: https://wordpress.org/themes/twentyseventeen/  
+Included as part of the following classes and functions:  
+- twentytwenty_unique_id()  
 
-## Changelog
+## Changelog  
 
-### 1.0
+### 1.0  
 
-* Released: November 12, 2019
+* Released: November 12, 2019  
 
-Initial release
+Initial release  

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ License: Creative Commons Zero (CC0), https://creativecommons.org/publicdomain/z
 URL: https://pxhere.com/en/photo/18153  
 
 Inter Font  
-Copyright (c) 2016-2019 The Inter Project Authors (me@rsms.me)  
+Copyright (c) 2016-2019 The Inter Project Authors (me@rsms.me)
 License: SIL Open Font License, 1.1, https://opensource.org/licenses/OFL-1.1  
 Source: https://rsms.me/inter/  
 
 Bespoke Icons Created For Twenty Twenty  
 License: Creative Commons Zero (CC0), https://creativecommons.org/publicdomain/zero/1.0/  
 List of bespoke icons:  
-- Search icon  
+- Search icon
 - Menu icon
 
 Feather Icons  
@@ -56,6 +56,22 @@ Socicon Icons
 License: SIL Open Font License, 1.1, https://opensource.org/licenses/OFL-1.1
 Source: https://www.socicon.com
 Used for all social menu icons except the link icon.
+
+Code from Twenty Nineteen
+Copyright (c) 2018 WordPress.org
+License: GPLv2
+Source: https://wordpress.org/themes/twentynineteen/
+Included as part of the following classes and functions:
+- TwentyTwenty_SVG_Icons
+- twentytwenty_the_theme_svg()
+- twentytwenty_get_theme_svg()
+
+Code from Twenty Seventeen
+Copyright (c) 2016 WordPress.org
+License: GPLv2
+Source: https://wordpress.org/themes/twentyseventeen/
+Included as part of the following classes and functions:
+- twentytwenty_unique_id()
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Included as part of the following classes and functions:
 - TwentyTwenty_SVG_Icons
 - twentytwenty_the_theme_svg()
 - twentytwenty_get_theme_svg()
+- twentytwenty_nav_menu_social_icons()
 
 Code from Twenty Seventeen
 Copyright (c) 2016 WordPress.org

--- a/readme.txt
+++ b/readme.txt
@@ -58,3 +58,19 @@ Socicon Icons
 License: SIL Open Font License, 1.1, https://opensource.org/licenses/OFL-1.1
 Source: https://www.socicon.com
 Used for all social menu icons except the link icon.
+
+Code from Twenty Nineteen
+Copyright (c) 2018 WordPress.org
+License: GPLv2
+Source: https://wordpress.org/themes/twentynineteen/
+Included as part of the following classes and functions:
+- TwentyTwenty_SVG_Icons
+- twentytwenty_the_theme_svg()
+- twentytwenty_get_theme_svg()
+
+Code from Twenty Seventeen
+Copyright (c) 2016 WordPress.org
+License: GPLv2
+Source: https://wordpress.org/themes/twentyseventeen/
+Included as part of the following classes and functions:
+- twentytwenty_unique_id()

--- a/readme.txt
+++ b/readme.txt
@@ -67,6 +67,7 @@ Included as part of the following classes and functions:
 - TwentyTwenty_SVG_Icons
 - twentytwenty_the_theme_svg()
 - twentytwenty_get_theme_svg()
+- twentytwenty_nav_menu_social_icons()
 
 Code from Twenty Seventeen
 Copyright (c) 2016 WordPress.org


### PR DESCRIPTION
Updates `readme.md` and `readme.txt` with licensing information about code brought over from Twenty Nineteen and Twenty Seventeen. Fixes #760.