### PR TITLE
Update the block editor color palette and its color classes

### DIFF
--- a/assets/css/editor-style-block.css
+++ b/assets/css/editor-style-block.css
@@ -1058,11 +1058,11 @@ hr.wp-block-separator.is-style-dots::before {
 
 	/* BLOCK: COLUMNS */
 
-	.editor-styles-wrapper .wp-block[data-type="core/column"] h1, 
-	.editor-styles-wrapper .wp-block[data-type="core/column"] h2, 
-	.editor-styles-wrapper .wp-block[data-type="core/column"] h3, 
-	.editor-styles-wrapper .wp-block[data-type="core/column"] h4, 
-	.editor-styles-wrapper .wp-block[data-type="core/column"] h5, 
+	.editor-styles-wrapper .wp-block[data-type="core/column"] h1,
+	.editor-styles-wrapper .wp-block[data-type="core/column"] h2,
+	.editor-styles-wrapper .wp-block[data-type="core/column"] h3,
+	.editor-styles-wrapper .wp-block[data-type="core/column"] h4,
+	.editor-styles-wrapper .wp-block[data-type="core/column"] h5,
 	.editor-styles-wrapper .wp-block[data-type="core/column"] h6 {
 		margin: 35px 0 20px 0;
 	}

--- a/assets/css/editor-style-block.css
+++ b/assets/css/editor-style-block.css
@@ -1056,6 +1056,17 @@ hr.wp-block-separator.is-style-dots::before {
 		padding: 0 45px;
 	}
 
+	/* BLOCK: COLUMNS */
+
+	.editor-styles-wrapper .wp-block[data-type="core/column"] h1, 
+	.editor-styles-wrapper .wp-block[data-type="core/column"] h2, 
+	.editor-styles-wrapper .wp-block[data-type="core/column"] h3, 
+	.editor-styles-wrapper .wp-block[data-type="core/column"] h4, 
+	.editor-styles-wrapper .wp-block[data-type="core/column"] h5, 
+	.editor-styles-wrapper .wp-block[data-type="core/column"] h6 {
+		margin: 35px 0 20px 0;
+	}
+
 	/* BLOCK: PULLQUOTE */
 
 	.editor-styles-wrapper .wp-block[data-type="core/pullquote"][data-align="right"] .block-editor-block-list__block-edit {

--- a/functions.php
+++ b/functions.php
@@ -614,7 +614,7 @@ function twentytwenty_get_elements_array() {
 			'accent'     => array(
 				'color'        => array( '.color-accent', '.color-accent-hover:hover', '.color-accent-hover:focus', '.has-accent-color', '.has-drop-cap:not(:focus):first-letter', '.wp-block-button.is-style-outline', 'a' ),
 				'border-color' => array( 'blockquote', '.border-color-accent', '.border-color-accent-hover:hover', '.border-color-accent-hover:focus' ),
-				'background'   => array( 'button:not(.toggle)', '.button', '.faux-button', '.wp-block-button__link', '.wp-block-file__button', 'input[type="button"]', 'input[type="reset"]', 'input[type="submit"]', '.bg-accent', '.bg-accent-hover:hover', '.bg-accent-hover:focus', '.has-accent-background-color', '.comment-reply-link' ),
+				'background'   => array( 'button:not(.toggle)', '.button', '.faux-button', '.wp-block-button__link', '.wp-block-file .wp-block-file__button', 'input[type="button"]', 'input[type="reset"]', 'input[type="submit"]', '.bg-accent', '.bg-accent-hover:hover', '.bg-accent-hover:focus', '.has-accent-background-color', '.comment-reply-link' ),
 				'fill'         => array( '.fill-children-accent', '.fill-children-accent *' ),
 			),
 			'background' => array(

--- a/functions.php
+++ b/functions.php
@@ -612,21 +612,21 @@ function twentytwenty_get_elements_array() {
 	$elements = array(
 		'content'       => array(
 			'accent'     => array(
-				'color'            => array( '.color-accent', '.color-accent-hover:hover', '.color-accent-hover:focus', '.has-accent-color', '.has-drop-cap:not(:focus):first-letter', '.wp-block-button.is-style-outline', 'a' ),
-				'border-color'     => array( 'blockquote', '.border-color-accent', '.border-color-accent-hover:hover', '.border-color-accent-hover:focus' ),
+				'color'        => array( '.color-accent', '.color-accent-hover:hover', '.color-accent-hover:focus', '.has-accent-color', '.has-drop-cap:not(:focus):first-letter', '.wp-block-button.is-style-outline', 'a' ),
+				'border-color' => array( 'blockquote', '.border-color-accent', '.border-color-accent-hover:hover', '.border-color-accent-hover:focus' ),
 				'background'   => array( 'button:not(.toggle)', '.button', '.faux-button', '.wp-block-button__link', '.wp-block-file__button', 'input[type="button"]', 'input[type="reset"]', 'input[type="submit"]', '.bg-accent', '.bg-accent-hover:hover', '.bg-accent-hover:focus', '.has-accent-background-color', '.comment-reply-link' ),
-				'fill'             => array( '.fill-children-accent', '.fill-children-accent *' ),
+				'fill'         => array( '.fill-children-accent', '.fill-children-accent *' ),
 			),
 			'background' => array(
 				'color'      => array( 'button', '.button', '.faux-button', '.wp-block-button__link', '.wp-block-button__link:active', '.wp-block-button__link:focus', '.wp-block-button__link:visited', '.wp-block-button__link:hover', '.wp-block-file__button', 'input[type="button"]', 'input[type="reset"]', 'input[type="submit"]', '.comment-reply-link' ),
 				'background' => array( '.has-background-background-color' ),
 			),
 			'text'       => array(
-				'color' => array( 'body', '.entry-title a', '.has-primary-color' ),
+				'color'      => array( 'body', '.entry-title a', '.has-primary-color' ),
 				'background' => array( '.entry-title a', '.has-primary-background-color' ),
 			),
 			'secondary'  => array(
-				'color' => array( 'cite', 'figcaption', '.wp-caption-text', '.post-meta', '.entry-content .wp-block-archives li', '.entry-content .wp-block-categories li', '.entry-content .wp-block-latest-posts li', '.wp-block-latest-comments__comment-date', '.wp-block-latest-posts__post-date', '.wp-block-embed figcaption', '.wp-block-image figcaption', '.wp-block-pullquote cite', '.comment-metadata', '.comment-respond .comment-notes', '.comment-respond .logged-in-as', '.pagination .dots', '.entry-content hr:not(.has-background)', 'hr.styled-separator', '.has-secondary-color' ),
+				'color'      => array( 'cite', 'figcaption', '.wp-caption-text', '.post-meta', '.entry-content .wp-block-archives li', '.entry-content .wp-block-categories li', '.entry-content .wp-block-latest-posts li', '.wp-block-latest-comments__comment-date', '.wp-block-latest-posts__post-date', '.wp-block-embed figcaption', '.wp-block-image figcaption', '.wp-block-pullquote cite', '.comment-metadata', '.comment-respond .comment-notes', '.comment-respond .logged-in-as', '.pagination .dots', '.entry-content hr:not(.has-background)', 'hr.styled-separator', '.has-secondary-color' ),
 				'background' => array( '.has-secondary-background-color' ),
 			),
 			'borders'    => array(
@@ -634,7 +634,7 @@ function twentytwenty_get_elements_array() {
 				'background'          => array( 'caption', 'code', 'code', 'kbd', 'samp', '.wp-block-table.is-style-stripes tbody tr:nth-child(odd)', '.has-subtle-background-background-color' ),
 				'border-bottom-color' => array( '.wp-block-table.is-style-stripes' ),
 				'border-top-color'    => array( '.wp-block-latest-posts.is-grid li' ),
-				'color'    => array( '.has-subtle-background-color' ),
+				'color'               => array( '.has-subtle-background-color' ),
 			),
 		),
 		'header-footer' => array(

--- a/functions.php
+++ b/functions.php
@@ -403,6 +403,11 @@ function twentytwenty_block_editor_settings() {
 			'color' => twentytwenty_get_color_for_area( 'content', 'accent' ),
 		),
 		array(
+			'name'  => __( 'Primary', 'twentytwenty' ),
+			'slug'  => 'primary',
+			'color' => twentytwenty_get_color_for_area( 'content', 'text' ),
+		),
+		array(
 			'name'  => __( 'Secondary', 'twentytwenty' ),
 			'slug'  => 'secondary',
 			'color' => twentytwenty_get_color_for_area( 'content', 'secondary' ),

--- a/functions.php
+++ b/functions.php
@@ -614,25 +614,27 @@ function twentytwenty_get_elements_array() {
 			'accent'     => array(
 				'color'            => array( '.color-accent', '.color-accent-hover:hover', '.color-accent-hover:focus', '.has-accent-color', '.has-drop-cap:not(:focus):first-letter', '.wp-block-button.is-style-outline', 'a' ),
 				'border-color'     => array( 'blockquote', '.border-color-accent', '.border-color-accent-hover:hover', '.border-color-accent-hover:focus' ),
-				'background'       => array( 'button:not(.toggle)', '.button', '.faux-button', '.wp-block-button__link', '.wp-block-file__button', 'input[type="button"]', 'input[type="reset"]', 'input[type="submit"]' ),
-				'background-color' => array( '.bg-accent', '.bg-accent-hover:hover', '.bg-accent-hover:focus', '.has-accent-background-color', '.comment-reply-link' ),
+				'background'   => array( 'button:not(.toggle)', '.button', '.faux-button', '.wp-block-button__link', '.wp-block-file__button', 'input[type="button"]', 'input[type="reset"]', 'input[type="submit"]', '.bg-accent', '.bg-accent-hover:hover', '.bg-accent-hover:focus', '.has-accent-background-color', '.comment-reply-link' ),
 				'fill'             => array( '.fill-children-accent', '.fill-children-accent *' ),
 			),
 			'background' => array(
 				'color'      => array( 'button', '.button', '.faux-button', '.wp-block-button__link', '.wp-block-button__link:active', '.wp-block-button__link:focus', '.wp-block-button__link:visited', '.wp-block-button__link:hover', '.wp-block-file__button', 'input[type="button"]', 'input[type="reset"]', 'input[type="submit"]', '.comment-reply-link' ),
-				'background' => array(),
+				'background' => array( '.has-background-background-color' ),
 			),
 			'text'       => array(
-				'color' => array( 'body', '.entry-title a' ),
+				'color' => array( 'body', '.entry-title a', '.has-primary-color' ),
+				'background' => array( '.entry-title a', '.has-primary-background-color' ),
 			),
 			'secondary'  => array(
-				'color' => array( 'cite', 'figcaption', '.wp-caption-text', '.post-meta', '.entry-content .wp-block-archives li', '.entry-content .wp-block-categories li', '.entry-content .wp-block-latest-posts li', '.wp-block-latest-comments__comment-date', '.wp-block-latest-posts__post-date', '.wp-block-embed figcaption', '.wp-block-image figcaption', '.wp-block-pullquote cite', '.comment-metadata', '.comment-respond .comment-notes', '.comment-respond .logged-in-as', '.pagination .dots', '.entry-content hr:not(.has-background)', 'hr.styled-separator' ),
+				'color' => array( 'cite', 'figcaption', '.wp-caption-text', '.post-meta', '.entry-content .wp-block-archives li', '.entry-content .wp-block-categories li', '.entry-content .wp-block-latest-posts li', '.wp-block-latest-comments__comment-date', '.wp-block-latest-posts__post-date', '.wp-block-embed figcaption', '.wp-block-image figcaption', '.wp-block-pullquote cite', '.comment-metadata', '.comment-respond .comment-notes', '.comment-respond .logged-in-as', '.pagination .dots', '.entry-content hr:not(.has-background)', 'hr.styled-separator', '.has-secondary-color' ),
+				'background' => array( '.has-secondary-background-color' ),
 			),
 			'borders'    => array(
 				'border-color'        => array( 'pre', 'fieldset', 'input', 'textarea', 'table', 'table *', 'hr' ),
-				'background'          => array( 'caption', 'code', 'code', 'kbd', 'samp', '.wp-block-table.is-style-stripes tbody tr:nth-child(odd)' ),
+				'background'          => array( 'caption', 'code', 'code', 'kbd', 'samp', '.wp-block-table.is-style-stripes tbody tr:nth-child(odd)', '.has-subtle-background-background-color' ),
 				'border-bottom-color' => array( '.wp-block-table.is-style-stripes' ),
 				'border-top-color'    => array( '.wp-block-latest-posts.is-grid li' ),
+				'color'    => array( '.has-subtle-background-color' ),
 			),
 		),
 		'header-footer' => array(

--- a/functions.php
+++ b/functions.php
@@ -438,13 +438,13 @@ function twentytwenty_block_editor_settings() {
 			array(
 				'name'      => _x( 'Small', 'Name of the small font size in the block editor', 'twentytwenty' ),
 				'shortName' => _x( 'S', 'Short name of the small font size in the block editor.', 'twentytwenty' ),
-				'size'      => 16,
+				'size'      => 18,
 				'slug'      => 'small',
 			),
 			array(
 				'name'      => _x( 'Regular', 'Name of the regular font size in the block editor', 'twentytwenty' ),
 				'shortName' => _x( 'M', 'Short name of the regular font size in the block editor.', 'twentytwenty' ),
-				'size'      => 18,
+				'size'      => 21,
 				'slug'      => 'regular',
 			),
 			array(

--- a/functions.php
+++ b/functions.php
@@ -623,7 +623,7 @@ function twentytwenty_get_elements_array() {
 			),
 			'text'       => array(
 				'color'      => array( 'body', '.entry-title a', '.has-primary-color' ),
-				'background' => array( '.entry-title a', '.has-primary-background-color' ),
+				'background' => array( '.has-primary-background-color' ),
 			),
 			'secondary'  => array(
 				'color'      => array( 'cite', 'figcaption', '.wp-caption-text', '.post-meta', '.entry-content .wp-block-archives li', '.entry-content .wp-block-categories li', '.entry-content .wp-block-latest-posts li', '.wp-block-latest-comments__comment-date', '.wp-block-latest-posts__post-date', '.wp-block-embed figcaption', '.wp-block-image figcaption', '.wp-block-pullquote cite', '.comment-metadata', '.comment-respond .comment-notes', '.comment-respond .logged-in-as', '.pagination .dots', '.entry-content hr:not(.has-background)', 'hr.styled-separator', '.has-secondary-color' ),

--- a/inc/custom-css.php
+++ b/inc/custom-css.php
@@ -120,14 +120,6 @@ if ( ! function_exists( 'twentytwenty_get_customizer_css' ) ) {
 				twentytwenty_generate_css( '.cover-header .entry-header *', 'color', $cover );
 			}
 
-			// Helper Classes.
-			if ( $accent && $accent !== $accent_default ) {
-				twentytwenty_generate_css( '.color-accent, .color-accent-hover:hover, .has-accent-color', 'color', $accent );
-				twentytwenty_generate_css( '.bg-accent, .bg-accent-hover:hover, .has-accent-background-color', 'background-color', $accent );
-				twentytwenty_generate_css( '.border-color-accent, .border-color-accent-hover:hover', 'border-color', $accent );
-				twentytwenty_generate_css( '.fill-children-accent, .fill-children-accent *', 'fill', $accent );
-			}
-
 			// Block Editor Styles.
 		} elseif ( 'block-editor' === $type ) {
 

--- a/style.css
+++ b/style.css
@@ -2581,6 +2581,38 @@ h2.entry-title {
 	background-color: #cd2653;
 }
 
+.has-primary-color {
+	color: #000;
+}
+
+.has-primary-background-color {
+	background-color: #000;
+}
+
+.has-secondary-color {
+	color: #6d6d6d;
+}
+
+.has-secondary-background-color {
+	background-color: #6d6d6d;
+}
+
+.has-subtle-background-color {
+	color: #dcd7ca;
+}
+
+.has-subtle-background-background-color {
+	background-color: #dcd7ca;
+}
+
+.has-background-color {
+	color: #f5efe0;
+}
+
+.has-background-background-color {
+	background-color: #f5efe0;
+}
+
 
 /* Block Typography Classes ------------------ */
 

--- a/style.css
+++ b/style.css
@@ -4054,6 +4054,9 @@ div.comment:first-of-type {
 .footer-nav-widgets-wrapper,
 #site-footer {
 	background-color: #fff;
+	border-color: #dedfdf;
+	border-style: solid;
+	border-width: 0;
 }
 
 .footer-top-visible .footer-nav-widgets-wrapper,
@@ -4063,7 +4066,7 @@ div.comment:first-of-type {
 
 .reduced-spacing.footer-top-visible .footer-nav-widgets-wrapper,
 .reduced-spacing.footer-top-hidden #site-footer {
-	border-top: 0.1rem solid #dedfdf;
+	border-top-width: 0.1rem;
 }
 
 .footer-top,


### PR DESCRIPTION
- Adds the "Primary" (text) color to the block editor palette, so all content colors in `accent_accessible_colors` can be used when editing content in the block editor.
- Updates style.css with styling of the `.has-[color]-color` and `.has-[color]-background-color` classes for all of the content colors in the editor palette, with the default colors set.
- Updates `twentytwenty_get_elements_array` with the new `.has-[color]-color` and `.has-[color]-background-color` classes, so the block editor color palette classes are updated when the color settings in the Customizer are changed.

![color-tests](https://user-images.githubusercontent.com/8181091/66253633-f20d8500-e76b-11e9-80ed-76aa218b9190.jpg)