### PR TITLE
Use contextual translation for a short prefixing string

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -385,7 +385,7 @@ function twentytwenty_get_post_meta( $post_id = null, $location = 'single-top' )
 							<?php twentytwenty_the_theme_svg( 'folder' ); ?>
 						</span>
 						<span class="meta-text">
-							<?php _e( 'In', 'twentytwenty' ); ?> <?php the_category( ', ' ); ?>
+							<?php _ex( 'In', 'A string that is output before one or more categories', 'twentytwenty' ); ?> <?php the_category( ', ' ); ?>
 						</span>
 					</li>
 					<?php


### PR DESCRIPTION
This uses a contextual translation for a very short string in the template thta is output before a list of one or more categories.

Fixes: #801 