### PR TITLE
Makes menu text inherit color

### DIFF
--- a/style-rtl.css
+++ b/style-rtl.css
@@ -5342,6 +5342,7 @@ a.to-the-top > * {
 		position: static;
 		padding-left: 20px;
 		font-size: 15px;
+		color: inherit;
 	}
 
 	/* Menu Modal ---------------------------- */


### PR DESCRIPTION
Applying to `style-rtl.css` styles already applied to `style.css` as discussed [here](https://github.com/WordPress/twentytwenty/pull/723#discussion_r331746079).