### PR TITLE
Fixed more tag output.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -482,16 +482,14 @@ function twentytwenty_block_editor_settings() {
 add_action( 'after_setup_theme', 'twentytwenty_block_editor_settings' );
 
 /**
- * Read More Link
- * Overwrite default (more ...) tag
+ * Modify the more tag.
+ *
+ * @param string $link The default HTML output for the more tag.
+ *
+ * @return string $link The modified more tag.
  */
-function twentytwenty_read_more_tag() {
-	return sprintf(
-		'<a href="%1$s" class="more-link faux-button">%2$s <span class="screen-reader-text">"%3$s"</span></a>',
-		esc_url( get_permalink( get_the_ID() ) ),
-		__( 'Continue reading', 'twentytwenty' ),
-		esc_html( get_the_title( get_the_ID() ) )
-	);
+function twentytwenty_read_more_tag( $link ) {
+	return preg_replace( '/class="(.*)"/iU', 'class="$1 faux-button"', $link);
 }
 add_filter( 'the_content_more_link', 'twentytwenty_read_more_tag' );
 

--- a/functions.php
+++ b/functions.php
@@ -482,28 +482,6 @@ function twentytwenty_block_editor_settings() {
 add_action( 'after_setup_theme', 'twentytwenty_block_editor_settings' );
 
 /**
- * Modify the more tag.
- *
- * @param string $link The default HTML output for the more tag.
- *
- * @return string $link The modified more tag.
- */
-function twentytwenty_read_more_tag( $link ) {
-	$search = array(
-		'/class="(.*)"/iU',
-		'/<\/a>/iU',
-	);
-
-	$replace = array(
-		'class="$1 faux-button"',
-		sprintf( '<span class="screen-reader-text">"%1$s"</span></a>', esc_html( get_the_title( get_the_ID() ) ) ),
-	);
-
-	return preg_replace( $search, $replace, $link );
-}
-add_filter( 'the_content_more_link', 'twentytwenty_read_more_tag' );
-
-/**
  * Enqueues scripts for customizer controls & settings.
  *
  * @since 1.0.0

--- a/functions.php
+++ b/functions.php
@@ -489,7 +489,17 @@ add_action( 'after_setup_theme', 'twentytwenty_block_editor_settings' );
  * @return string $link The modified more tag.
  */
 function twentytwenty_read_more_tag( $link ) {
-	return preg_replace( '/class="(.*)"/iU', 'class="$1 faux-button"', $link );
+	$search = array(
+	  '/class="(.*)"/iU',
+	  '/<\/a>/iU',
+	);
+
+	$replace = array(
+		'class="$1 faux-button"',
+		sprintf( '<span class="screen-reader-text">"%1$s"</span></a>', esc_html( get_the_title( get_the_ID() ) ) ),
+	);
+
+	return preg_replace( $search, $replace, $link );
 }
 add_filter( 'the_content_more_link', 'twentytwenty_read_more_tag' );
 

--- a/functions.php
+++ b/functions.php
@@ -490,8 +490,8 @@ add_action( 'after_setup_theme', 'twentytwenty_block_editor_settings' );
  */
 function twentytwenty_read_more_tag( $link ) {
 	$search = array(
-	  '/class="(.*)"/iU',
-	  '/<\/a>/iU',
+		'/class="(.*)"/iU',
+		'/<\/a>/iU',
 	);
 
 	$replace = array(

--- a/functions.php
+++ b/functions.php
@@ -489,7 +489,7 @@ add_action( 'after_setup_theme', 'twentytwenty_block_editor_settings' );
  * @return string $link The modified more tag.
  */
 function twentytwenty_read_more_tag( $link ) {
-	return preg_replace( '/class="(.*)"/iU', 'class="$1 faux-button"', $link);
+	return preg_replace( '/class="(.*)"/iU', 'class="$1 faux-button"', $link );
 }
 add_filter( 'the_content_more_link', 'twentytwenty_read_more_tag' );
 

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -33,7 +33,7 @@
 			if ( is_search() || ! is_singular() && 'summary' === get_theme_mod( 'blog_content', 'full' ) ) {
 				the_excerpt();
 			} else {
-				the_content();
+				the_content( __( 'Continue reading', 'twentytwenty' ) );
 			}
 			?>
 

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -33,7 +33,7 @@
 			if ( is_search() || ! is_singular() && 'summary' === get_theme_mod( 'blog_content', 'full' ) ) {
 				the_excerpt();
 			} else {
-				the_content( __( 'Continue reading', 'twentytwenty' ) );
+				the_content( sprintf( '<span class="faux-button">%1$s</span> <span class="screen-reader-text">"%2$s"</span>', __( 'Continue reading' ), get_the_title() ) );
 			}
 			?>
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/twentytwenty/issues/791.

Is there a reason why the theme wouldn't use the default output from the more tag? What it's trying to do seems similar to what the default output does. 

This fix uses the default output and modifies it so the styling is correct.