### PR TITLE
Make the CSS for hiding the RSS icon stricter

### DIFF
--- a/style.css
+++ b/style.css
@@ -4018,7 +4018,7 @@ div.comment:first-of-type {
 
 /* Widget: RSS ------------------------------- */
 
-.widget_rss a.rsswidget:first-of-type {
+.widget_rss .widget-title a.rsswidget:first-of-type {
 	display: none;
 }
 


### PR DESCRIPTION
This makes sure the style rule added in #709 only affects the title section for targeting the RSS feed icon.

Fixed #836 