### PR TITLE
Fix: Current menu ancestor is not highlighting issue.

### DIFF
--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1560,7 +1560,8 @@ ul.primary-menu {
 }
 
 .primary-menu a:hover,
-.primary-menu a:focus {
+.primary-menu a:focus,
+.primary-menu .current_page_ancestor {
 	text-decoration: underline;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1801,7 +1801,8 @@ button.close-nav-toggle .toggle-text {
 
 .modal-menu a:focus,
 .modal-menu a:hover,
-.modal-menu li.current-menu-item > .ancestor-wrapper > a {
+.modal-menu li.current-menu-item > .ancestor-wrapper > a,
+.modal-menu li.current_page_ancestor > .ancestor-wrapper > a {
 	text-decoration: underline;
 }
 

--- a/style.css
+++ b/style.css
@@ -1803,7 +1803,8 @@ button.close-nav-toggle .toggle-text {
 
 .modal-menu a:focus,
 .modal-menu a:hover,
-.modal-menu li.current-menu-item > .ancestor-wrapper > a {
+.modal-menu li.current-menu-item > .ancestor-wrapper > a,
+.modal-menu li.current_page_ancestor > .ancestor-wrapper > a {
 	text-decoration: underline;
 }
 

--- a/style.css
+++ b/style.css
@@ -1562,7 +1562,8 @@ ul.primary-menu {
 }
 
 .primary-menu a:hover,
-.primary-menu a:focus {
+.primary-menu a:focus,
+.primary-menu .current_page_ancestor {
 	text-decoration: underline;
 }
 


### PR DESCRIPTION
Now the current page ancestor menu is not highlighting. It should highlight.

It works for both menus (`page_menu` and `nav_menu`).

**Before screenshot:**

![twentytwenty-current-ancestor-menu-not-highlighting](https://maheshwaghmare.files.wordpress.com/2019/10/twentytwenty-current-ancestor-menu-not-highlighting.png)

**After screenshot:**

![twentytwenty-current-ancestor-menu-highlighting](https://maheshwaghmare.files.wordpress.com/2019/10/twentytwenty-current-ancestor-menu-highlighting.png)

---

Also, Fixed highlight the model menu page ancestor menu item.

**Before screenshot:**

![twentytwenty-current-ancestor-menu-highlighting](https://maheshwaghmare.files.wordpress.com/2019/10/twentytwenty-model-menu-beofre.png)

**After screenshot:**

![twentytwenty-current-ancestor-menu-highlighting](https://maheshwaghmare.files.wordpress.com/2019/10/twentytwenty-model-menu-after.png)



