### PR TITLE
Update aria-expanded

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -621,9 +621,6 @@ twentytwenty.toggles = {
 				_doc.querySelector( '*[data-toggle-target="' + targetString + '"]' ).classList.toggle( activeClass );
 			}
 
-			// Toggle aria-expanded on the target
-			twentytwentyToggleAttribute( target, 'aria-expanded', 'true', 'false' );
-
 			// Toggle aria-expanded on the toggle
 			twentytwentyToggleAttribute( toggle, 'aria-expanded', 'true', 'false' );
 

--- a/classes/class-twentytwenty-walker-page.php
+++ b/classes/class-twentytwenty-walker-page.php
@@ -131,7 +131,7 @@ if ( ! class_exists( 'TwentyTwenty_Walker_Page' ) ) {
 					$toggle_duration      = twentytwenty_toggle_duration();
 
 					// Add the sub menu toggle.
-					$args['list_item_after'] .= '<button class="toggle sub-menu-toggle fill-children-current-color" data-toggle-target="' . $toggle_target_string . '" data-toggle-type="slidetoggle" data-toggle-duration="' . absint( $toggle_duration ) . '"><span class="screen-reader-text">' . __( 'Show sub menu', 'twentytwenty' ) . '</span>' . twentytwenty_get_theme_svg( 'chevron-down' ) . '</button>';
+					$args['list_item_after'] .= '<button class="toggle sub-menu-toggle fill-children-current-color" data-toggle-target="' . $toggle_target_string . '" data-toggle-type="slidetoggle" data-toggle-duration="' . absint( $toggle_duration ) . '" aria-expanded="false"><span class="screen-reader-text">' . __( 'Show sub menu', 'twentytwenty' ) . '</span>' . twentytwenty_get_theme_svg( 'chevron-down' ) . '</button>';
 
 				}
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -543,7 +543,7 @@ function twentytwenty_add_sub_toggles_to_main_menu( $args, $item, $depth ) {
 			$toggle_duration      = twentytwenty_toggle_duration();
 
 			// Add the sub menu toggle.
-			$args->after .= '<button class="toggle sub-menu-toggle fill-children-current-color" data-toggle-target="' . $toggle_target_string . '" data-toggle-type="slidetoggle" data-toggle-duration="' . absint( $toggle_duration ) . '"><span class="screen-reader-text">' . __( 'Show sub menu', 'twentytwenty' ) . '</span>' . twentytwenty_get_theme_svg( 'chevron-down' ) . '</button>';
+			$args->after .= '<button class="toggle sub-menu-toggle fill-children-current-color" data-toggle-target="' . $toggle_target_string . '" data-toggle-type="slidetoggle" data-toggle-duration="' . absint( $toggle_duration ) . '" aria-expanded="false"><span class="screen-reader-text">' . __( 'Show sub menu', 'twentytwenty' ) . '</span>' . twentytwenty_get_theme_svg( 'chevron-down' ) . '</button>';
 
 		}
 

--- a/template-parts/modal-menu.php
+++ b/template-parts/modal-menu.php
@@ -9,7 +9,7 @@
 
 ?>
 
-<div class="menu-modal cover-modal header-footer-group" data-modal-target-string=".menu-modal" aria-expanded="false">
+<div class="menu-modal cover-modal header-footer-group" data-modal-target-string=".menu-modal">
 
 	<div class="menu-modal-inner modal-inner">
 

--- a/template-parts/modal-search.php
+++ b/template-parts/modal-search.php
@@ -8,7 +8,7 @@
  */
 
 ?>
-<div class="search-modal cover-modal header-footer-group" data-modal-target-string=".search-modal" aria-expanded="false">
+<div class="search-modal cover-modal header-footer-group" data-modal-target-string=".search-modal">
 
 	<div class="search-modal-inner modal-inner">
 
@@ -22,7 +22,7 @@
 			);
 			?>
 
-			<button class="toggle search-untoggle close-search-toggle fill-children-current-color" data-toggle-target=".search-modal" data-toggle-body-class="showing-search-modal" data-set-focus=".search-modal .search-field">
+			<button class="toggle search-untoggle close-search-toggle fill-children-current-color" data-toggle-target=".search-modal" data-toggle-body-class="showing-search-modal" data-set-focus=".search-modal .search-field" aria-expanded="false">
 				<span class="screen-reader-text"><?php _e( 'Close search', 'twentytwenty' ); ?></span>
 				<?php twentytwenty_the_theme_svg( 'cross' ); ?>
 			</button><!-- .search-toggle -->


### PR DESCRIPTION
This removes aria-expanded from the wrapping div of the search modal and expanded menu.
It also removes the aria-expanded from the submenu items, and adds it to the submenu toggle buttons.

Fixes #850
Partial fix for #633
