### PR TITLE
Add filter for the archive title

### DIFF
--- a/index.php
+++ b/index.php
@@ -51,6 +51,8 @@ get_header();
 		$archive_title    = get_the_archive_title();
 		$archive_subtitle = get_the_archive_description();
 	}
+	
+	$archive_title = apply_filters( 'twentytwenty_archive_title', $archive_title );
 
 	if ( $archive_title || $archive_subtitle ) {
 		?>


### PR DESCRIPTION
As previously mentioned in #289, a filter for the archive title would be a nice and reasonable enhancement for developers. Themes like Chaplin or Twenty Seventeen display the title on the main posts page.