### PR TITLE
Prevent filtering edit_post_link in the admin

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -190,6 +190,9 @@ function twentytwenty_the_post_meta( $post_id = null, $location = 'single-top' )
  * @param string $text    Anchor text.
  */
 function twentytwenty_edit_post_link( $link, $post_id, $text ) {
+	if ( is_admin() ) {
+		return $link;
+	}
 
 	$edit_url = get_edit_post_link( $post_id );
 


### PR DESCRIPTION
In the AMP plugin there are links to in the classic publish metabox for viewing and editing a given URL, looking like this:

> <img width="277" alt="Screen Shot 2019-10-17 at 09 18 47" src="https://user-images.githubusercontent.com/134745/67027913-48a98600-f0bf-11e9-915b-34bf0714d634.png">

When Twenty Twenty is active, this appears broken:

> <img width="277" alt="Screen Shot 2019-10-17 at 09 18 31" src="https://user-images.githubusercontent.com/134745/67027941-52cb8480-f0bf-11e9-9491-1450f1712bc5.png">

The `twentytwenty_edit_post_link` function should short-circuit when `is_admin()`. This PR implements that change.

Introduced in #449.