### PR TITLE
Improve color calculations

### DIFF
--- a/assets/js/color-calculations.js
+++ b/assets/js/color-calculations.js
@@ -36,9 +36,9 @@ function _twentyTwentyColor( backgroundColor, accentHue ) {
 _twentyTwentyColor.prototype.setAccentColorsArray = function() {
 	var self = this,
 		minSaturation = 55,
-		maxSaturation = 90,
-		minLightness = 25,
-		maxLighness = 75,
+		maxSaturation = 100,
+		minLightness = 15,
+		maxLighness = 85,
 		stepSaturation = 2.5,
 		stepLightness = 2.5,
 		pushColor = function() {
@@ -47,7 +47,21 @@ _twentyTwentyColor.prototype.setAccentColorsArray = function() {
 					s: s,
 					l: l
 				} ),
-				item;
+				item,
+				/**
+				 * Get a score for this color in contrast to its background color and surrounding text.
+				 *
+				 * @since 1.0.0
+				 * @param {number} contrastBackground - WCAG contrast with the background color.
+				 * @param {number} contrastSurroundingText - WCAG contrast with surrounding text.
+				 * @return {number} - 0 is best, higher numbers have bigger difference with the desired scores.
+				 */
+				getScore = function( contrastBackground, contrastSurroundingText ) {
+					var diffBackground = ( 7 >= contrastBackground ) ? 0 : Math.abs( 7 - contrastBackground ),
+						diffSurroundingText = ( 3 >= contrastSurroundingText ) ? 0 : Math.abs( 3 - contrastSurroundingText );
+
+					return diffBackground + diffSurroundingText;
+				};
 
 			item = {
 				color: colorObj,
@@ -62,7 +76,7 @@ _twentyTwentyColor.prototype.setAccentColorsArray = function() {
 
 			// Get a score for this color by multiplying the 2 contrasts.
 			// We'll use that to sort the array.
-			item.score = item.contrastBackground * item.contrastText;
+			item.score = getScore( item.contrastBackground * item.contrastText );
 
 			self.accentColorsArray.push( item );
 		},
@@ -89,7 +103,7 @@ _twentyTwentyColor.prototype.setAccentColorsArray = function() {
 
 	// Sort colors by contrast.
 	this.accentColorsArray.sort( function( a, b ) {
-		return b.score - a.score;
+		return a.score - b.score;
 	} );
 	return this;
 };

--- a/assets/js/color-calculations.js
+++ b/assets/js/color-calculations.js
@@ -57,8 +57,8 @@ _twentyTwentyColor.prototype.setAccentColorsArray = function() {
 				 * @return {number} - 0 is best, higher numbers have bigger difference with the desired scores.
 				 */
 				getScore = function( contrastBackground, contrastSurroundingText ) {
-					var diffBackground = ( 7 >= contrastBackground ) ? 0 : Math.abs( 7 - contrastBackground ),
-						diffSurroundingText = ( 3 >= contrastSurroundingText ) ? 0 : Math.abs( 3 - contrastSurroundingText );
+					var diffBackground = ( 7 >= contrastBackground ) ? 0 : 7 - contrastBackground,
+						diffSurroundingText = ( 3 >= contrastSurroundingText ) ? 0 : 3 - contrastSurroundingText;
 
 					return diffBackground + diffSurroundingText;
 				};

--- a/assets/js/color-calculations.js
+++ b/assets/js/color-calculations.js
@@ -35,12 +35,12 @@ function _twentyTwentyColor( backgroundColor, accentHue ) {
  */
 _twentyTwentyColor.prototype.setAccentColorsArray = function() {
 	var self = this,
-		minSaturation = 55,
+		minSaturation = 65,
 		maxSaturation = 100,
-		minLightness = 15,
-		maxLighness = 85,
-		stepSaturation = 2.5,
-		stepLightness = 2.5,
+		minLightness = 30,
+		maxLighness = 80,
+		stepSaturation = 2,
+		stepLightness = 2,
 		pushColor = function() {
 			var colorObj = new Color( {
 					h: self.accentHue,


### PR DESCRIPTION
The previous implementation had a flaw that this PR fixes.
We were previously calculating the "score" of a color by multiplying the backround-contrast with the surrounding-text contrast. Then we were sorting the array of colors highest score first, and we were returning the item with the highest value.
This new version does something a lot better:
It calculates the score for colors by comparing them to the desired values for AAA compliance.
So the score is calculated like this now:
* If contrast with background is below 7, get the difference with the desired value (`7 - contrast`).
* If contrast with surrounding text is below 3, get the difference with the desired value (`3 - contrast`).
* return the sum of the `diff` values
* Sort by smaller score

The "score" is now difference-with-optimal-values. So a score of `0` is 100% AAA compliant.
The previous implementation was crude and ineffective. This one is much closer to how things _should_ be.

It also addresses some comments I saw (sorry, no links... I've been reading things here and there these past few days) and I get the impression there have been some complaints about the colors that the scripts chooses.
The previous ranges for the queried colors were:
* Saturation: `55 - 90`
* Lightness: `15 - 85`

The PR changes these edges to be
* Saturation: `65 - 100`
* Lightness: `30 - 80`

The result is slightly more vibrant colors.
Also changed the step resolution from `2.5` to `2`, so it will now check more colors than before in order to find a suitable accent for the selected hue.