### PR TITLE
Cleaner header flex layout

### DIFF
--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1287,10 +1287,9 @@ ul.social-icons li {
 /* Header Titles ----------------------------- */
 
 .header-titles-wrapper {
-	align-items: center;
 	display: flex;
-	justify-content: center;
-	padding: 0 4rem;
+	justify-content: space-between;
+	align-items: center;
 	text-align: center;
 }
 
@@ -1398,10 +1397,7 @@ body:not(.enable-search-modal) .site-logo img {
 }
 
 .header-inner .toggle {
-	align-items: center;
-	display: flex;
 	overflow: visible;
-	padding: 0 2rem;
 }
 
 .header-inner .toggle svg {
@@ -1415,8 +1411,9 @@ body:not(.enable-search-modal) .site-logo img {
 }
 
 .toggle-inner {
-	height: 2.3rem;
-	position: relative;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
 }
 
 .toggle-icon {
@@ -1428,11 +1425,9 @@ body:not(.enable-search-modal) .site-logo img {
 	color: #6d6d6d;
 	font-size: 1rem;
 	font-weight: 600;
-	position: absolute;
-	top: calc(100% + 0.5rem);
-	width: auto;
 	white-space: nowrap;
 	word-break: break-all;
+	margin-top: 5px;
 }
 
 .overlay-header .toggle-text {
@@ -1446,12 +1441,6 @@ body:not(.enable-search-modal) .site-logo img {
 
 /* Search Toggle ----------------------------- */
 
-.search-toggle {
-	position: absolute;
-	bottom: 0;
-	right: 0;
-	top: 0;
-}
 
 .search-toggle .toggle-icon,
 .search-toggle svg {
@@ -1460,20 +1449,7 @@ body:not(.enable-search-modal) .site-logo img {
 	width: 2.3rem;
 }
 
-.search-toggle .toggle-text {
-	right: 0;
-	text-align: right;
-}
-
 /* Navigation Toggle ------------------------- */
-
-.nav-toggle {
-	position: absolute;
-	bottom: 0;
-	left: 0;
-	top: 0;
-	width: 6.6rem;
-}
 
 .nav-toggle .toggle-icon,
 .nav-toggle svg {
@@ -1481,14 +1457,6 @@ body:not(.enable-search-modal) .site-logo img {
 	width: 2.6rem;
 }
 
-.nav-toggle .toggle-inner {
-	padding-top: 0.8rem;
-}
-
-.nav-toggle .toggle-text {
-	left: 0;
-	text-align: left;
-}
 
 /* Primary Menu ---------------------------- */
 
@@ -3015,7 +2983,7 @@ figure.wp-block-gallery.alignfull {
 	background: #fff;
 	border-radius: 50%;
 	color: #cd2653;
-	content: "”";
+	content: "â€";
 	display: block;
 	font-size: 6.2rem;
 	font-weight: 500;
@@ -4041,7 +4009,7 @@ div.comment:first-of-type {
 }
 
 .widget_rss cite::before {
-	content: "— ";
+	content: "â€” ";
 }
 
 /* Widget: Search ---------------------------- */

--- a/style.css
+++ b/style.css
@@ -1293,9 +1293,10 @@ ul.social-icons li {
 /* Header Titles ----------------------------- */
 
 .header-titles-wrapper {
-	display: flex;
-	justify-content: space-between;
 	align-items: center;
+	display: flex;
+	justify-content: center;
+	padding: 0 4rem;
 	text-align: center;
 }
 
@@ -1403,7 +1404,10 @@ body:not(.enable-search-modal) .site-logo img {
 }
 
 .header-inner .toggle {
+	align-items: center;
+	display: flex;
 	overflow: visible;
+	padding: 0 2rem;
 }
 
 .header-inner .toggle svg {
@@ -1417,9 +1421,8 @@ body:not(.enable-search-modal) .site-logo img {
 }
 
 .toggle-inner {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
+	height: 2.3rem;
+	position: relative;
 }
 
 .toggle-icon {
@@ -1431,9 +1434,11 @@ body:not(.enable-search-modal) .site-logo img {
 	color: #6d6d6d;
 	font-size: 1rem;
 	font-weight: 600;
+	position: absolute;
+	top: calc(100% + 0.5rem);
+	width: auto;
 	white-space: nowrap;
 	word-break: break-all;
-	margin-top: 5px;
 }
 
 .overlay-header .toggle-text {
@@ -1447,6 +1452,12 @@ body:not(.enable-search-modal) .site-logo img {
 
 /* Search Toggle ----------------------------- */
 
+.search-toggle {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	top: 0;
+}
 
 .search-toggle .toggle-icon,
 .search-toggle svg {
@@ -1455,7 +1466,20 @@ body:not(.enable-search-modal) .site-logo img {
 	width: 2.3rem;
 }
 
+.search-toggle .toggle-text {
+	left: 0;
+	text-align: left;
+}
+
 /* Navigation Toggle ------------------------- */
+
+.nav-toggle {
+	position: absolute;
+	bottom: 0;
+	right: 0;
+	top: 0;
+	width: 6.6rem;
+}
 
 .nav-toggle .toggle-icon,
 .nav-toggle svg {
@@ -1463,6 +1487,14 @@ body:not(.enable-search-modal) .site-logo img {
 	width: 2.6rem;
 }
 
+.nav-toggle .toggle-inner {
+	padding-top: 0.8rem;
+}
+
+.nav-toggle .toggle-text {
+	right: 0;
+	text-align: right;
+}
 
 /* Primary Menu ---------------------------- */
 
@@ -2993,7 +3025,7 @@ figure.wp-block-gallery.alignfull {
 	background: #fff;
 	border-radius: 50%;
 	color: #cd2653;
-	content: "â€";
+	content: "”";
 	display: block;
 	font-size: 6.2rem;
 	font-weight: 500;
@@ -4027,7 +4059,7 @@ div.comment:first-of-type {
 }
 
 .widget_rss cite::before {
-	content: "â€” ";
+	content: "— ";
 }
 
 /* Widget: Search ---------------------------- */

--- a/style.css
+++ b/style.css
@@ -1293,10 +1293,9 @@ ul.social-icons li {
 /* Header Titles ----------------------------- */
 
 .header-titles-wrapper {
-	align-items: center;
 	display: flex;
-	justify-content: center;
-	padding: 0 4rem;
+	justify-content: space-between;
+	align-items: center;
 	text-align: center;
 }
 
@@ -1404,10 +1403,7 @@ body:not(.enable-search-modal) .site-logo img {
 }
 
 .header-inner .toggle {
-	align-items: center;
-	display: flex;
 	overflow: visible;
-	padding: 0 2rem;
 }
 
 .header-inner .toggle svg {
@@ -1421,8 +1417,9 @@ body:not(.enable-search-modal) .site-logo img {
 }
 
 .toggle-inner {
-	height: 2.3rem;
-	position: relative;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
 }
 
 .toggle-icon {
@@ -1434,11 +1431,9 @@ body:not(.enable-search-modal) .site-logo img {
 	color: #6d6d6d;
 	font-size: 1rem;
 	font-weight: 600;
-	position: absolute;
-	top: calc(100% + 0.5rem);
-	width: auto;
 	white-space: nowrap;
 	word-break: break-all;
+	margin-top: 5px;
 }
 
 .overlay-header .toggle-text {
@@ -1452,12 +1447,6 @@ body:not(.enable-search-modal) .site-logo img {
 
 /* Search Toggle ----------------------------- */
 
-.search-toggle {
-	position: absolute;
-	bottom: 0;
-	left: 0;
-	top: 0;
-}
 
 .search-toggle .toggle-icon,
 .search-toggle svg {
@@ -1466,20 +1455,7 @@ body:not(.enable-search-modal) .site-logo img {
 	width: 2.3rem;
 }
 
-.search-toggle .toggle-text {
-	left: 0;
-	text-align: left;
-}
-
 /* Navigation Toggle ------------------------- */
-
-.nav-toggle {
-	position: absolute;
-	bottom: 0;
-	right: 0;
-	top: 0;
-	width: 6.6rem;
-}
 
 .nav-toggle .toggle-icon,
 .nav-toggle svg {
@@ -1487,14 +1463,6 @@ body:not(.enable-search-modal) .site-logo img {
 	width: 2.6rem;
 }
 
-.nav-toggle .toggle-inner {
-	padding-top: 0.8rem;
-}
-
-.nav-toggle .toggle-text {
-	right: 0;
-	text-align: right;
-}
 
 /* Primary Menu ---------------------------- */
 
@@ -3025,7 +2993,7 @@ figure.wp-block-gallery.alignfull {
 	background: #fff;
 	border-radius: 50%;
 	color: #cd2653;
-	content: "”";
+	content: "â€";
 	display: block;
 	font-size: 6.2rem;
 	font-weight: 500;
@@ -4059,7 +4027,7 @@ div.comment:first-of-type {
 }
 
 .widget_rss cite::before {
-	content: "— ";
+	content: "â€” ";
 }
 
 /* Widget: Search ---------------------------- */


### PR DESCRIPTION
Remove unnecessary absolute positions and paddings on .header-titles-wrapper and its mobile buttons by adjusting flex properties of elements. 
It also fixes issue #864 

p.d. I'm a newbie on contributing on GitHub, thanks to Hacktoberfest, so please sorry for whatever I might be doing wrong. My WordPress user is decrecementofeliz.