### PR TITLE
Prevent the header background color option from being previewed with the cover template.

### DIFF
--- a/assets/js/customize-preview.js
+++ b/assets/js/customize-preview.js
@@ -94,7 +94,7 @@
 	api( 'header_footer_background_color', function( value ) {
 		value.bind( function( to ) {
 			// Add background color to header and footer wrappers.
-			$( '#site-header,#site-footer' ).css( 'background-color', to );
+			$( 'body:not(.overlay-header)#site-header:not ,#site-footer' ).css( 'background-color', to );
 
 			// Change body classes if this is the same background-color as the content background.
 			if ( to.toLowerCase() === api( 'background_color' ).get().toLowerCase() ) {


### PR DESCRIPTION
Prevent the header and footer background color from being previewed in the customizer when the cover template is used.

Fixes #590 