### PR TITLE
Post Navigation: Remove Underline for Arrows

### DIFF
--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2530,11 +2530,6 @@ h2.entry-title {
 	text-decoration: none;
 }
 
-.pagination-single a:hover,
-.pagination-single a:focus {
-	text-decoration: underline;
-}
-
 .pagination-single a + a {
 	margin-top: 1rem;
 }

--- a/style.css
+++ b/style.css
@@ -2538,11 +2538,6 @@ h2.entry-title {
 	text-decoration: none;
 }
 
-.pagination-single a:hover,
-.pagination-single a:focus {
-	text-decoration: underline;
-}
-
 .pagination-single a + a {
 	margin-top: 1rem;
 }


### PR DESCRIPTION
This removes the underline that appears when hovering over an arrow, which can be found as part of the Post Navigation at the bottom of a post. The rest of the link will be underlined if hovered over the arrow, so I doubt this is an accessibility problem either, but it fixes #899.

**Before:**

<img width="328" alt="Screenshot 2019-10-21 at 20 32 09" src="https://user-images.githubusercontent.com/43215253/67236855-fca16d00-f441-11e9-9533-48a571591697.png">

**After:**

<img width="346" alt="Screenshot 2019-10-21 at 20 31 31" src="https://user-images.githubusercontent.com/43215253/67236866-01feb780-f442-11e9-9fc8-16b37ecd9da4.png">
