### PR TITLE
Fix: Aligned Button Block in Cover Block

### DIFF
--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4994,11 +4994,11 @@ a.to-the-top > * {
 	}
 
 	.alignleft {
-		margin: 0.3rem 0 2rem 2rem;
+		margin: 0.3rem 2rem 2rem 0;
 	}
 
 	.alignright {
-		margin: 0.3rem 2rem 2rem 0;
+		margin: 0.3rem 0 2rem 2rem;
 	}
 
 	.alignwide,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2179,11 +2179,11 @@ body.template-full-width .entry-content {
 }
 
 body.template-full-width .entry-content .alignleft {
-	margin-right: 0;
+	margin-left: 0;
 }
 
 body.template-full-width .entry-content .alignright {
-	margin-left: 0;
+	margin-right: 0;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2862,10 +2862,6 @@ h2.entry-title {
 	margin-bottom: 0;
 }
 
-.entry-content .wp-block-cover .wp-block-button {
-	margin: 0;
-}
-
 /* Block: Cover ------------------------------ */
 
 .wp-block-cover-image .wp-block-cover__inner-container,
@@ -2887,6 +2883,10 @@ h2.entry-title {
 .wp-block-cover-image h2,
 .wp-block-cover h2 {
 	font-size: 3.2rem;
+}
+
+.entry-content .wp-block-cover .wp-block-button {
+	margin: 0;
 }
 
 /* Block: Embed ------------------------------ */

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2862,6 +2862,10 @@ h2.entry-title {
 	margin-bottom: 0;
 }
 
+.entry-content .wp-block-cover .wp-block-button {
+	margin: 0;
+}
+
 /* Block: Cover ------------------------------ */
 
 .wp-block-cover-image .wp-block-cover__inner-container,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2885,10 +2885,6 @@ h2.entry-title {
 	font-size: 3.2rem;
 }
 
-.entry-content .wp-block-cover .wp-block-button {
-	margin: 0;
-}
-
 /* Block: Embed ------------------------------ */
 
 /* Block: File ------------------------------- */
@@ -4381,11 +4377,15 @@ a.to-the-top > * {
 
 	/* ALIGNMENT CLASSES */
 
-	.entry-content .alignleft {
+	.entry-content > .alignleft,
+	.entry-content > p .alignleft,
+	.entry-content > .wp-block-image .alignleft {
 		margin-left: calc(( 100vw - 58rem - 8rem ) / -2);
 	}
 
-	.entry-content .alignright {
+	.entry-content > .alignright, 
+	.entry-content > p .alignright, 
+	.entry-content > .wp-block-image .alignright {
 		margin-right: calc(( 100vw - 58rem - 8rem ) / -2);
 	}
 
@@ -5788,11 +5788,15 @@ a.to-the-top > * {
 
 	/* ALIGNMENT CLASSES */
 
-	.entry-content .alignleft {
+	.entry-content > .alignleft,
+	.entry-content > p .alignleft,
+	.entry-content > .wp-block-image .alignleft {
 		margin-left: -31rem;
 	}
 
-	.entry-content .alignright {
+	.entry-content > .alignright, 
+	.entry-content > p .alignright, 
+	.entry-content > .wp-block-image .alignright {
 		margin-right: -31rem;
 	}
 

--- a/style.css
+++ b/style.css
@@ -2899,6 +2899,10 @@ h2.entry-title {
 	font-size: 3.2rem;
 }
 
+.entry-content .wp-block-cover .wp-block-button {
+	margin: 0;
+}
+
 /* Block: Embed ------------------------------ */
 
 /* Block: File ------------------------------- */

--- a/style.css
+++ b/style.css
@@ -2899,10 +2899,6 @@ h2.entry-title {
 	font-size: 3.2rem;
 }
 
-.entry-content .wp-block-cover .wp-block-button {
-	margin: 0;
-}
-
 /* Block: Embed ------------------------------ */
 
 /* Block: File ------------------------------- */
@@ -4407,13 +4403,17 @@ a.to-the-top > * {
 
 	/* ALIGNMENT CLASSES */
 
-	.entry-content .alignleft {
+	.entry-content > .alignleft,
+	.entry-content > p .alignleft,
+	.entry-content > .wp-block-image .alignleft {
 
 		/*rtl:ignore*/
 		margin-left: calc(( 100vw - 58rem - 8rem ) / -2);
 	}
 
-	.entry-content .alignright {
+	.entry-content > .alignright,
+	.entry-content > p .alignright,
+	.entry-content > .wp-block-image .alignright {
 
 		/*rtl:ignore*/
 		margin-right: calc(( 100vw - 58rem - 8rem ) / -2);
@@ -5822,13 +5822,17 @@ a.to-the-top > * {
 
 	/* ALIGNMENT CLASSES */
 
-	.entry-content .alignleft {
+	.entry-content > .alignleft,
+	.entry-content > p .alignleft,
+	.entry-content > .wp-block-image .alignleft  {
 
 		/*rtl:ignore*/
 		margin-left: -31rem;
 	}
 
-	.entry-content .alignright {
+	.entry-content > .alignright, 
+	.entry-content > p .alignright, 
+	.entry-content > .wp-block-image .alignright {
 
 		/*rtl:ignore*/
 		margin-right: -31rem;

--- a/style.css
+++ b/style.css
@@ -2189,12 +2189,15 @@ body.template-cover .entry-header {
 body.template-full-width .entry-content {
 	max-width: none;
 }
-
 body.template-full-width .entry-content .alignleft {
+
+	/*rtl:ignore*/
 	margin-left: 0;
 }
 
 body.template-full-width .entry-content .alignright {
+
+	/*rtl:ignore*/
 	margin-right: 0;
 }
 
@@ -5824,14 +5827,14 @@ a.to-the-top > * {
 
 	.entry-content > .alignleft,
 	.entry-content > p .alignleft,
-	.entry-content > .wp-block-image .alignleft  {
+	.entry-content > .wp-block-image .alignleft {
 
 		/*rtl:ignore*/
 		margin-left: -31rem;
 	}
 
-	.entry-content > .alignright, 
-	.entry-content > p .alignright, 
+	.entry-content > .alignright,
+	.entry-content > p .alignright,
 	.entry-content > .wp-block-image .alignright {
 
 		/*rtl:ignore*/

--- a/style.css
+++ b/style.css
@@ -5028,10 +5028,14 @@ a.to-the-top > * {
 	}
 
 	.alignleft {
+		
+		/*rtl:ignore*/
 		margin: 0.3rem 2rem 2rem 0;
 	}
 
 	.alignright {
+		
+		 /*rtl:ignore*/
 		margin: 0.3rem 0 2rem 2rem;
 	}
 

--- a/style.css
+++ b/style.css
@@ -5028,14 +5028,14 @@ a.to-the-top > * {
 	}
 
 	.alignleft {
-		
+
 		/*rtl:ignore*/
 		margin: 0.3rem 2rem 2rem 0;
 	}
 
 	.alignright {
-		
-		 /*rtl:ignore*/
+
+		/*rtl:ignore*/
 		margin: 0.3rem 0 2rem 2rem;
 	}
 

--- a/style.css
+++ b/style.css
@@ -2189,6 +2189,7 @@ body.template-cover .entry-header {
 body.template-full-width .entry-content {
 	max-width: none;
 }
+
 body.template-full-width .entry-content .alignleft {
 
 	/*rtl:ignore*/


### PR DESCRIPTION
This PR overrides the margin of the button block inside a cover block (which is why the extra `.entry-content` is necessary).

Fixes #917

**Before:**

<img width="371" alt="Screenshot 2019-10-23 at 18 08 28" src="https://user-images.githubusercontent.com/43215253/67417373-7fe8cd00-f5c0-11e9-9c92-0b1c5f7da96f.png">

**After:**

<img width="374" alt="Screenshot 2019-10-23 at 18 08 34" src="https://user-images.githubusercontent.com/43215253/67417383-84ad8100-f5c0-11e9-8fc7-181a0f1b5968.png">
