### PR TITLE
Ensure link to read more is preserved in Continue reading button

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -234,7 +234,7 @@ add_action( 'wp_print_footer_scripts', 'twentytwenty_skip_link_focus_fix' );
  */
 function twentytwenty_non_latin_languages() {
 	$custom_css = TwentyTwenty_Non_Latin_Languages::get_non_latin_css( 'front-end' );
-	
+
 	if ( $custom_css ) {
 		wp_add_inline_style( 'twentytwenty-style', $custom_css );
 	}
@@ -566,7 +566,7 @@ add_action( 'after_setup_theme', 'twentytwenty_block_editor_settings' );
  * @return string $html
  */
 function twentytwenty_read_more_tag( $html ) {
-	return preg_replace( '/<a.*>(.*)<\/a>/iU', sprintf( '<span class="faux-button">$1</span> <span class="screen-reader-text">"%1$s"</span>', get_the_title( get_the_ID() ) ), $html );
+	return preg_replace( '/<a.*>.*<\/a>/iU', sprintf( '<span class="faux-button">$0</span> <span class="screen-reader-text">"%1$s"</span>', get_the_title( get_the_ID() ) ), $html );
 }
 
 add_filter( 'the_content_more_link', 'twentytwenty_read_more_tag' );

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -696,11 +696,16 @@ button,
 	button,
 	.button,
 	.faux-button,
-	.faux-button.more-link,
+	.faux-button .more-link,
 	.wp-block-button__link,
 	.wp-block-file__button {
 		font-family: "Inter var", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, sans-serif;
 	}
+}
+
+.faux-button .more-link {
+	color: #fff;
+	text-decoration: none;
 }
 
 input,
@@ -811,6 +816,8 @@ button:hover,
 .button:hover,
 .faux-button:focus,
 .faux-button:hover,
+.faux-button .more-link:focus,
+.faux-button .more-link:hover,
 .wp-block-button .wp-block-button__link:focus,
 .wp-block-button .wp-block-button__link:hover,
 .wp-block-file .wp-block-file__button:focus,

--- a/style.css
+++ b/style.css
@@ -700,11 +700,16 @@ button,
 	button,
 	.button,
 	.faux-button,
-	.faux-button.more-link,
+	.faux-button .more-link,
 	.wp-block-button__link,
 	.wp-block-file__button {
 		font-family: "Inter var", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, sans-serif;
 	}
+}
+
+.faux-button .more-link {
+	color: #fff;
+	text-decoration: none;
 }
 
 input,
@@ -817,6 +822,8 @@ button:hover,
 .button:hover,
 .faux-button:focus,
 .faux-button:hover,
+.faux-button .more-link:focus,
+.faux-button .more-link:hover,
 .wp-block-button .wp-block-button__link:focus,
 .wp-block-button .wp-block-button__link:hover,
 .wp-block-file .wp-block-file__button:focus,


### PR DESCRIPTION
Fixes #945 

The filter which modifies the "Read More" link ("Continue reading" in twentytwenty) was stripping out the URL for the extra content on the post page.

This PR preserves the link and modifies styles so that link appears correctly (default anchor styles were making the text red instead of white)

To test:

* On any feed page, click the "Continue reading" button. You should be taken to the post.
* On master, the continue reading button is not a link, so it does nothing.