### PR TITLE
Adjust regex to ensure links are not stripped from 'Continue Reading'

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -566,7 +566,7 @@ add_action( 'after_setup_theme', 'twentytwenty_block_editor_settings' );
  * @return string $html
  */
 function twentytwenty_read_more_tag( $html ) {
-	return preg_replace( '/<a.*>(.*)<\/a>/iU', sprintf( '<span class="faux-button">$1</span> <span class="screen-reader-text">"%1$s"</span>', get_the_title( get_the_ID() ) ), $html );
+	return preg_replace( '/<a(.*)>(.*)<\/a>/iU', sprintf( '<a$1><span class="faux-button">$2</span> <span class="screen-reader-text">"%1$s"</span></a>', get_the_title( get_the_ID() ) ), $html );
 }
 
 add_filter( 'the_content_more_link', 'twentytwenty_read_more_tag' );


### PR DESCRIPTION
This PR is a mini fix for the PR open in #946. The method is taken from https://github.com/WordPress/twentytwenty/pull/946#issuecomment-548964756

Credits for this fix go to @byalextran and @gravityrail and the other PR may still be considered in future. This is just the absolute min required to correct the base problem but there may be more nuances to deal with (like styles).