### PR TITLE
Take 2 - Update #828 to address the starter_content vanishing on mobile

### DIFF
--- a/inc/starter-content.php
+++ b/inc/starter-content.php
@@ -175,16 +175,10 @@ function twentytwenty_get_starter_content() {
 			'primary'  => array(
 				'name'  => __( 'Primary', 'twentytwenty' ),
 				'items' => array(
-					'page_contact',
-				),
-			),
-			// Assign a menu to the "expanded" (modal) menu location.
-			'expanded' => array(
-				'name'  => __( 'Primary', 'twentytwenty' ),
-				'items' => array(
 					'link_home', // Note that the core "home" page is actually a link in case a static front page is not used.
 					'page_about',
 					'page_blog',
+					'page_contact',
 				),
 			),
 			// Assign a menu to the "social" location.


### PR DESCRIPTION
Update #828 to address the starter_content vanishing on mobile with the default menu setup. This will remove the expanded desktop menu and place all items in the primary menu.

This replaced #876 

Slack thread from WP 5.3 RC4 - https://wordpress.slack.com/archives/C02RQBWTW/p1572998276403100