### PR TITLE
Fixes for the Columns block

### DIFF
--- a/style-rtl.css
+++ b/style-rtl.css
@@ -5277,6 +5277,11 @@ a.to-the-top > * {
 		margin-bottom: 0;
 	}
 
+	.wp-block-columns.alignwide + .wp-block-columns.alignwide,
+	.wp-block-columns.alignfull + .wp-block-columns.alignfull {
+		margin-top: -2.8rem;
+	}
+
 	.alignfull .wp-block-column:first-child > p,
 	.alignfull:not(.has-background) .wp-block-group__inner-container > p:not(.has-background-color) {
 		padding-right: 2rem;
@@ -5510,7 +5515,7 @@ a.to-the-top > * {
 
 	.wp-block-columns.alignwide + .wp-block-columns.alignwide,
 	.wp-block-columns.alignfull + .wp-block-columns.alignfull {
-		margin-top: -5.2rem;
+		margin-top: -4.8rem;
 	}
 
 	/* BLOCK: GALLERY */

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2862,6 +2862,12 @@ h2.entry-title {
 
 /* Block: Columns ---------------------------- */
 
+.wp-block-columns.alignfull,
+.alignfull:not(.has-background) .wp-block-columns {
+	padding-right: 2rem;
+	padding-left: 2rem;
+}
+
 .wp-block-column {
 	margin-bottom: 3.2rem;
 }
@@ -2987,6 +2993,11 @@ figure.wp-block-gallery.alignfull {
 .wp-block-group__inner-container,
 .entry-content .wp-block-group p {
 	max-width: 100%;
+}
+
+.alignfull:not(.has-background) > .wp-block-group__inner-container > p:not(.has-background-color) {
+	padding-right: 2rem;
+	padding-left: 2rem;
 }
 
 /* Block: Image ------------------------------ */
@@ -4347,36 +4358,6 @@ a.to-the-top > * {
 
 }
 
-@media ( max-width: 599px ) {
-
-	/* Blocks -------------------------------- */
-
-	/* BLOCK: COLUMNS */
-
-	.alignfull:not(.has-background) .wp-block-column > p:not(.has-background-color),
-	.alignfull:not(.has-background) .wp-block-group__inner-container > p:not(.has-background-color) {
-		max-width: calc(100% - 4rem);
-		margin: auto;
-	}
-}
-
-@media ( min-width: 600px ) and ( max-width: 781px ) {
-
-	/* Blocks -------------------------------- */
-
-	/* BLOCK: COLUMNS */
-
-	.alignfull:not(.has-background) .wp-block-column:nth-child(odd) > p:not(.has-background-color),
-	.alignfull:not(.has-background) .wp-block-group__inner-container > p:not(.has-background-color) {
-		padding-right: 2rem;
-	}
-
-	.alignfull:not(.has-background) .wp-block-column:nth-child(even) > p:not(.has-background-color),
-	.alignfull:not(.has-background) .wp-block-group__inner-container > p:not(.has-background-color) {
-		padding-left: 2rem;
-	}
-}
-
 @media ( min-width: 660px ) {
 
 	/* Blocks -------------------------------- */
@@ -5280,16 +5261,6 @@ a.to-the-top > * {
 	.wp-block-columns.alignwide + .wp-block-columns.alignwide,
 	.wp-block-columns.alignfull + .wp-block-columns.alignfull {
 		margin-top: -2.8rem;
-	}
-
-	.alignfull .wp-block-column:first-child > p,
-	.alignfull:not(.has-background) .wp-block-group__inner-container > p:not(.has-background-color) {
-		padding-right: 2rem;
-	}
-
-	.alignfull:not(.has-background) .wp-block-column:last-child > p,
-	.alignfull:not(.has-background) .wp-block-group__inner-container > p:not(.has-background-color) {
-		padding-left: 2rem;
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -5311,6 +5311,11 @@ a.to-the-top > * {
 		margin-bottom: 0;
 	}
 
+	.wp-block-columns.alignwide + .wp-block-columns.alignwide,
+	.wp-block-columns.alignfull + .wp-block-columns.alignfull {
+		margin-top: -2.8rem;
+	}
+
 	.alignfull .wp-block-column:first-child > p,
 	.alignfull:not(.has-background) .wp-block-group__inner-container > p:not(.has-background-color) {
 		padding-left: 2rem;
@@ -5544,7 +5549,7 @@ a.to-the-top > * {
 
 	.wp-block-columns.alignwide + .wp-block-columns.alignwide,
 	.wp-block-columns.alignfull + .wp-block-columns.alignfull {
-		margin-top: -5.2rem;
+		margin-top: -4.8rem;
 	}
 
 	/* BLOCK: GALLERY */

--- a/style.css
+++ b/style.css
@@ -2876,6 +2876,12 @@ h2.entry-title {
 
 /* Block: Columns ---------------------------- */
 
+.wp-block-columns.alignfull,
+.alignfull:not(.has-background) .wp-block-columns {
+	padding-left: 2rem;
+	padding-right: 2rem;
+}
+
 .wp-block-column {
 	margin-bottom: 3.2rem;
 }
@@ -3001,6 +3007,11 @@ figure.wp-block-gallery.alignfull {
 .wp-block-group__inner-container,
 .entry-content .wp-block-group p {
 	max-width: 100%;
+}
+
+.alignfull:not(.has-background) > .wp-block-group__inner-container > p:not(.has-background-color) {
+	padding-left: 2rem;
+	padding-right: 2rem;
 }
 
 /* Block: Image ------------------------------ */
@@ -4369,36 +4380,6 @@ a.to-the-top > * {
 
 }
 
-@media ( max-width: 599px ) {
-
-	/* Blocks -------------------------------- */
-
-	/* BLOCK: COLUMNS */
-
-	.alignfull:not(.has-background) .wp-block-column > p:not(.has-background-color),
-	.alignfull:not(.has-background) .wp-block-group__inner-container > p:not(.has-background-color) {
-		max-width: calc(100% - 4rem);
-		margin: auto;
-	}
-}
-
-@media ( min-width: 600px ) and ( max-width: 781px ) {
-
-	/* Blocks -------------------------------- */
-
-	/* BLOCK: COLUMNS */
-
-	.alignfull:not(.has-background) .wp-block-column:nth-child(odd) > p:not(.has-background-color),
-	.alignfull:not(.has-background) .wp-block-group__inner-container > p:not(.has-background-color) {
-		padding-left: 2rem;
-	}
-
-	.alignfull:not(.has-background) .wp-block-column:nth-child(even) > p:not(.has-background-color),
-	.alignfull:not(.has-background) .wp-block-group__inner-container > p:not(.has-background-color) {
-		padding-right: 2rem;
-	}
-}
-
 @media ( min-width: 660px ) {
 
 	/* Blocks -------------------------------- */
@@ -5314,16 +5295,6 @@ a.to-the-top > * {
 	.wp-block-columns.alignwide + .wp-block-columns.alignwide,
 	.wp-block-columns.alignfull + .wp-block-columns.alignfull {
 		margin-top: -2.8rem;
-	}
-
-	.alignfull .wp-block-column:first-child > p,
-	.alignfull:not(.has-background) .wp-block-group__inner-container > p:not(.has-background-color) {
-		padding-left: 2rem;
-	}
-
-	.alignfull:not(.has-background) .wp-block-column:last-child > p,
-	.alignfull:not(.has-background) .wp-block-group__inner-container > p:not(.has-background-color) {
-		padding-right: 2rem;
 	}
 }
 


### PR DESCRIPTION
This PR contains fixes for the Columns block issues created by @yannickiki earlier today.

Fixes #963 and #961 by removing the paragraph-only padding used for the first and last columns in full-width columns blocks previously, and replaces it with a horizontal padding on the block as a whole. This made it possible to reduce the amount of CSS quite a bit, since it removed the need for different solutions for different breakpoints.

Before | After
------------ | -------------
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/8181091/68340649-210a7400-00e7-11ea-8713-527bbf7efe5e.png"> | <img width="1440" alt="image" src="https://user-images.githubusercontent.com/8181091/68340569-f4565c80-00e6-11ea-8639-899cd1a49c42.png">

Fixes #960 by adjusting the spacing between stacked Columns blocks between `782px` and `999px`. Also tweaked the margin on desktop, to make the horizontal margin between stacked columns blocks `32px` (same as the gutter) on all screen sizes.

Before | After
------------ | -------------
<img width="1111" alt="image" src="https://user-images.githubusercontent.com/8181091/68340870-85c5ce80-00e7-11ea-83bd-f5377a89069c.png"> | <img width="1111" alt="image" src="https://user-images.githubusercontent.com/8181091/68340977-befe3e80-00e7-11ea-9fcc-bd7f0373b2b8.png">

