### PR TITLE
Fix ability to expand nav submenus on large-viewport touch interfaces

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -68,6 +68,21 @@ if ( ! Element.prototype.matches ) {
 		};
 }
 
+// Add a class to the body for when touch is enabled for browsers that don't support media queries
+// for interaction media features. Adapted from <https://codepen.io/Ferie/pen/vQOMmO>
+( function() {
+	var matchMedia = function() {
+		// Include the 'heartz' as a way to have a non matching MQ to help terminate the join. See <https://git.io/vznFH>.
+		var prefixes = [ '-webkit-', '-moz-', '-o-', '-ms-' ];
+		var query = [ '(', prefixes.join( 'touch-enabled),(' ), 'heartz', ')' ].join( '' );
+		return window.matchMedia && window.matchMedia( query ).matches;
+	};
+
+	if ( ( 'ontouchstart' in window ) || ( window.DocumentTouch && document instanceof window.DocumentTouch ) || matchMedia() ) {
+		document.body.classList.add( 'touch-enabled' );
+	}
+}() );
+
 /*	-----------------------------------------------------------------------------------------------
 	Cover Modals
 --------------------------------------------------------------------------------------------------- */

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -523,37 +523,6 @@ twentytwenty.primaryMenu = {
 				self = self.parentElement;
 			}
 		}
-
-		/**
-		 * Toggles `focus` class to allow submenu access on tablets.
-		 */
-		( function( menuObj ) {
-			var touchStartFn, j,
-				parentLink = menuObj.querySelectorAll( '.primary-menu .menu-item-has-children > a' );
-
-			if ( 'ontouchstart' in window ) {
-				touchStartFn = function( e ) {
-					var menuItem = this.parentNode;
-
-					if ( ! menuItem.classList.contains( 'focus' ) ) {
-						e.preventDefault();
-						for ( j = 0; j < menuItem.parentNode.children.length; ++j ) {
-							if ( menuItem === menuItem.parentNode.children[j] ) {
-								continue;
-							}
-							menuItem.parentNode.children[i].classList.remove( 'focus' );
-						}
-						menuItem.classList.add( 'focus' );
-					} else {
-						menuItem.classList.remove( 'focus' );
-					}
-				};
-
-				for ( j = 0; j < parentLink.length; ++j ) {
-					parentLink[j].addEventListener( 'touchstart', touchStartFn, false );
-				}
-			}
-		}( menu ) );
 	}
 }; // twentytwenty.primaryMenu
 

--- a/style.css
+++ b/style.css
@@ -1703,6 +1703,18 @@ ul.primary-menu {
 
 }
 
+/* Repeat previous rules for IE11 (when JS enabled for polyfill). */
+body.touch-enabled .primary-menu > li.menu-item-has-children > a {
+	padding-right: 0;
+	margin-right: 2rem;
+}
+
+body.touch-enabled .primary-menu ul li.menu-item-has-children > a {
+	margin-right: 4.5rem;
+	padding-right: 0;
+	width: unset;
+}
+
 /* -------------------------------------------------------------------------- */
 
 /*	5. Menu Modal

--- a/style.css
+++ b/style.css
@@ -1687,6 +1687,22 @@ ul.primary-menu {
 	transform: rotate(180deg);
 }
 
+/* Nav submenu expansion on large-viewport touch screens (e.g. tablets) */
+@media (hover: none) and (pointer: coarse) {
+
+	.primary-menu > li.menu-item-has-children > a {
+		padding-right: 0;
+		margin-right: 2rem;
+	}
+
+	.primary-menu ul li.menu-item-has-children > a {
+		margin-right: 4.5rem;
+		padding-right: 0;
+		width: unset;
+	}
+
+}
+
 /* -------------------------------------------------------------------------- */
 
 /*	5. Menu Modal

--- a/style.css
+++ b/style.css
@@ -1687,8 +1687,12 @@ ul.primary-menu {
 	transform: rotate(180deg);
 }
 
-/* Nav submenu expansion on large-viewport touch screens (e.g. tablets) */
-@media (hover: none) and (pointer: coarse) {
+/*
+ * Enable nav submenu expansion with tapping on arrows on large-viewport
+ * touch interfaces (e.g. tablets or laptops with touch screens).
+ * These rules are supported by all browsers (>IE11) and when JS is disabled.
+ */
+@media (any-pointer: coarse) {
 
 	.primary-menu > li.menu-item-has-children > a {
 		padding-right: 0;


### PR DESCRIPTION
In #949 changes were merged to fix #790, the inability to access a submenu item of the Desktop Horizontal Menu on tablet (>1000px). However, I [found](https://github.com/WordPress/twentytwenty/pull/949#issuecomment-551220080) the fix is not working:

![image](https://user-images.githubusercontent.com/134745/68419332-df151880-014e-11ea-9c9d-7d9e9f32d6b2.png)

An alternative approach to adding JS to support touch interfaces is rather to use CSS, specifically media queries for interaction media features ([caniuse](https://caniuse.com/#feat=css-media-interaction), currently 92.57% of browsers globally).

An added benefit of using CSS here is that it will ensure that the nav menus work when JS is turned off in the browser (or it fails to load, or it is an AMP page). Nevertheless, since IE11 doesn't support this media query, perhaps some JS logic should be included to add a `touch-enabled` class name on the `body` and then add CSS rules for them as well (for IE11 users who have JS enabled: <7.43% of global users).

Props to @pierlon who found this solution when devising an AMP-compatible way to make the submenus accessible on large-viewport touch interfaces: https://github.com/ampproject/amp-wp/pull/3696.