### PR TITLE
Load the starter content only when within the customizer

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -119,8 +119,15 @@ function twentytwenty_theme_support() {
 	// Add support for full and wide align images.
 	add_theme_support( 'align-wide' );
 
-	// Adds starter content to highlight the theme on fresh sites.
-	add_theme_support( 'starter-content', twentytwenty_get_starter_content() );
+	/*
+	 * Adds starter content to highlight the theme on fresh sites.
+	 * This is done conditionally to avoid loading the starter content on every
+	 * page load, as it is a one-off operation only needed once in the customizer.
+	 */
+	if ( is_customize_preview() ) {
+		require get_template_directory() . '/inc/starter-content.php';
+		add_theme_support( 'starter-content', twentytwenty_get_starter_content() );
+	}
 
 	// Add theme support for selective refresh for widgets.
 	add_theme_support( 'customize-selective-refresh-widgets' );
@@ -166,9 +173,6 @@ require get_template_directory() . '/classes/class-twentytwenty-non-latin-langua
 
 // Custom CSS.
 require get_template_directory() . '/inc/custom-css.php';
-
-// Custom starter content to highlight the theme on fresh sites.
-require get_template_directory() . '/inc/starter-content.php';
 
 /**
  * Register and Enqueue Styles.
@@ -234,7 +238,7 @@ add_action( 'wp_print_footer_scripts', 'twentytwenty_skip_link_focus_fix' );
  */
 function twentytwenty_non_latin_languages() {
 	$custom_css = TwentyTwenty_Non_Latin_Languages::get_non_latin_css( 'front-end' );
-	
+
 	if ( $custom_css ) {
 		wp_add_inline_style( 'twentytwenty-style', $custom_css );
 	}


### PR DESCRIPTION
To avoid parsing the starter content on every single page request, we only
add the theme support for the starter content when `is_customizer_preview()` is
true.

Fixes #973