### PR TITLE
Update outline for input fields

### DIFF
--- a/style-rtl.css
+++ b/style-rtl.css
@@ -826,6 +826,26 @@ input[type="submit"]:hover {
 	text-decoration: underline;
 }
 
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="url"]:focus,
+input[type="password"]:focus,
+input[type="search"]:focus,
+input[type="number"]:focus,
+input[type="tel"]:focus,
+input[type="range"]:focus,
+input[type="date"]:focus,
+input[type="month"]:focus,
+input[type="week"]:focus,
+input[type="time"]:focus,
+input[type="datetime"]:focus,
+input[type="datetime-local"]:focus,
+input[type="color"]:focus,
+textarea:focus {
+	outline: thin dotted;
+	outline-offset: 2px;
+}
+
 /* Tables ------------------------------------ */
 
 table {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -830,7 +830,6 @@ input[type="text"]:focus,
 input[type="email"]:focus,
 input[type="url"]:focus,
 input[type="password"]:focus,
-input[type="search"]:focus,
 input[type="number"]:focus,
 input[type="tel"]:focus,
 input[type="range"]:focus,
@@ -842,8 +841,12 @@ input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
 textarea:focus {
+	border-color: currentColor;
+}
+
+input[type="search"]:focus {
 	outline: thin dotted;
-	outline-offset: 2px;
+	outline-offset: -4px;
 }
 
 /* Tables ------------------------------------ */

--- a/style.css
+++ b/style.css
@@ -832,6 +832,26 @@ input[type="submit"]:hover {
 	text-decoration: underline;
 }
 
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="url"]:focus,
+input[type="password"]:focus,
+input[type="search"]:focus,
+input[type="number"]:focus,
+input[type="tel"]:focus,
+input[type="range"]:focus,
+input[type="date"]:focus,
+input[type="month"]:focus,
+input[type="week"]:focus,
+input[type="time"]:focus,
+input[type="datetime"]:focus,
+input[type="datetime-local"]:focus,
+input[type="color"]:focus,
+textarea:focus {
+	outline: thin dotted;
+	outline-offset: 2px;
+}
+
 /* Tables ------------------------------------ */
 
 table {

--- a/style.css
+++ b/style.css
@@ -836,7 +836,6 @@ input[type="text"]:focus,
 input[type="email"]:focus,
 input[type="url"]:focus,
 input[type="password"]:focus,
-input[type="search"]:focus,
 input[type="number"]:focus,
 input[type="tel"]:focus,
 input[type="range"]:focus,
@@ -848,8 +847,12 @@ input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
 textarea:focus {
+	border-color: currentColor;
+}
+
+input[type="search"]:focus {
 	outline: thin dotted;
-	outline-offset: 2px;
+	outline-offset: -4px;
 }
 
 /* Tables ------------------------------------ */


### PR DESCRIPTION
Adds a very basic 1px dotted outline for input fields when they are focused.

This outline will be inconsistent for Chrome users. Ideally the outline should be consistent across the entire theme, not only for input fields, and independent on browsers.

Quick fix for https://github.com/WordPress/twentytwenty/issues/975

