### PR TITLE
doctype uppercase to lowercase

### DIFF
--- a/header.php
+++ b/header.php
@@ -9,7 +9,7 @@
  * @since 1.0.0
  */
 
-?><!DOCTYPE html>
+?><!doctype html>
 
 <html class="no-js" <?php language_attributes(); ?>>
 


### PR DESCRIPTION
There's no reason for the uppercase doctype. It was discussed and committed to _s repo also