### PR TITLE
Garrett eclipse starter content mobile menu

### DIFF
--- a/inc/starter-content.php
+++ b/inc/starter-content.php
@@ -181,6 +181,16 @@ function twentytwenty_get_starter_content() {
 					'page_contact',
 				),
 			),
+			// This replicates primary just to demonstrate the expanded menu.
+			'expanded' => array(
+				'name'  => __( 'Primary', 'twentytwenty' ),
+				'items' => array(
+					'link_home', // Note that the core "home" page is actually a link in case a static front page is not used.
+					'page_about',
+					'page_blog',
+					'page_contact',
+				),
+			),
 			// Assign a menu to the "social" location.
 			'social'   => array(
 				'name'  => __( 'Social Links Menu', 'twentytwenty' ),


### PR DESCRIPTION
This pulls in PR #955 which fixes a problem with some content not being reachable due to menu configurations. It also replicates the same menu entries in the expanded location to demonstrate it's abilities.