### PR TITLE
Reset the word-break property on `.screen-reader-text`

### DIFF
--- a/style.css
+++ b/style.css
@@ -180,6 +180,7 @@ path {
 	position: absolute !important;
 	width: 1px;
 	word-wrap: normal !important;
+	word-break: normal;
 }
 
 .screen-reader-text:focus {


### PR DESCRIPTION
This prevents an issue that causes screen readers to loose the spaces 
between words and read everything consecutively, with no word breaks, in 
a statement.

This is an attempted fix for #972 but with the one caveat noted in this comment: https://github.com/WordPress/twentytwenty/issues/972#issuecomment-551935050 