### PR TITLE
Swap slug for `regular` font size to `normal` so it shows as default

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -535,7 +535,7 @@ function twentytwenty_block_editor_settings() {
 				'name'      => _x( 'Regular', 'Name of the regular font size in the block editor', 'twentytwenty' ),
 				'shortName' => _x( 'M', 'Short name of the regular font size in the block editor.', 'twentytwenty' ),
 				'size'      => 21,
-				'slug'      => 'regular',
+				'slug'      => 'normal',
 			),
 			array(
 				'name'      => _x( 'Large', 'Name of the large font size in the block editor', 'twentytwenty' ),


### PR DESCRIPTION
By default `Small` was displayed in selector as the font size when in reality `Regular` was the size that was in use for the text.

This PR only changes the slug from `regular` (name remains 'Regular') to `normal` allowing alphabetical sorting to handle displaying 'Regular' by default in dropdown to match the text size.