### PR TITLE
Excluding pullquote block from width resize rules

### DIFF
--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4488,7 +4488,7 @@ a.to-the-top > * {
 	[class*="wp-block"].alignwide [class*="__inner-container"] > .alignleft,
 	[class*="wp-block"].alignwide [class*="__inner-container"] > p .alignleft,
 	[class*="wp-block"].alignwide [class*="__inner-container"] > .wp-block-image .alignleft,
-	[class*="wp-block"].alignfull [class*="__inner-container"] > .alignleft,
+	[class*="wp-block"].alignfull [class*="__inner-container"] > .alignleft:not(.wp-block-pullquote),
 	[class*="wp-block"].alignfull [class*="__inner-container"] > p .alignleft,
 	[class*="wp-block"].alignfull [class*="__inner-container"] > .wp-block-image .alignleft {
 		margin-left: calc(( 100vw - 58rem - 8rem ) / -2);
@@ -4506,7 +4506,7 @@ a.to-the-top > * {
 	[class*="wp-block"].alignwide [class*="__inner-container"] > .alignright,
 	[class*="wp-block"].alignwide [class*="__inner-container"] > p .alignright,
 	[class*="wp-block"].alignwide [class*="__inner-container"] > .wp-block-image .alignright,
-	[class*="wp-block"].alignfull [class*="__inner-container"] > .alignright,
+	[class*="wp-block"].alignfull [class*="__inner-container"] > .alignright:not(.wp-block-pullquote),
 	[class*="wp-block"].alignfull [class*="__inner-container"] > p .alignright,
 	[class*="wp-block"].alignfull [class*="__inner-container"] > .wp-block-image .alignright {
 		margin-right: calc(( 100vw - 58rem - 8rem ) / -2);

--- a/style.css
+++ b/style.css
@@ -4514,7 +4514,7 @@ a.to-the-top > * {
 	[class*="wp-block"].alignwide [class*="__inner-container"] > .alignleft,
 	[class*="wp-block"].alignwide [class*="__inner-container"] > p .alignleft,
 	[class*="wp-block"].alignwide [class*="__inner-container"] > .wp-block-image .alignleft,
-	[class*="wp-block"].alignfull [class*="__inner-container"] > .alignleft,
+	[class*="wp-block"].alignfull [class*="__inner-container"] > .alignleft:not(.wp-block-pullquote),
 	[class*="wp-block"].alignfull [class*="__inner-container"] > p .alignleft,
 	[class*="wp-block"].alignfull [class*="__inner-container"] > .wp-block-image .alignleft {
 
@@ -4536,7 +4536,7 @@ a.to-the-top > * {
 	[class*="wp-block"].alignwide [class*="__inner-container"] > .alignright,
 	[class*="wp-block"].alignwide [class*="__inner-container"] > p .alignright,
 	[class*="wp-block"].alignwide [class*="__inner-container"] > .wp-block-image .alignright,
-	[class*="wp-block"].alignfull [class*="__inner-container"] > .alignright,
+	[class*="wp-block"].alignfull [class*="__inner-container"] > .alignright:not(.wp-block-pullquote),
 	[class*="wp-block"].alignfull [class*="__inner-container"] > p .alignright,
 	[class*="wp-block"].alignfull [class*="__inner-container"] > .wp-block-image .alignright {
 


### PR DESCRIPTION
Fixes the issue mentioned here after merging the new responsive width logic: 
https://github.com/WordPress/twentytwenty/pull/701#issuecomment-552655172

After fix: 
![2019-11-11 20 12 30](https://user-images.githubusercontent.com/709581/68633356-9b5c3f00-04bf-11ea-8b96-847a1839c03c.gif)
