### PR TITLE
Adding `.has-background` excluding condition to wide and full group-blocks.

### DIFF
--- a/style-rtl.css
+++ b/style-rtl.css
@@ -5139,8 +5139,8 @@ a.to-the-top > * {
 		margin: 0.3rem 0 2rem 2rem;
 	}
 
-	.entry-content > .alignwide:not(.wp-block-group),
-	.entry-content > .alignfull:not(.wp-block-group) {
+	.entry-content > .alignwide:not(.wp-block-group.has-background),
+	.entry-content > .alignfull:not(.wp-block-group.has-background) {
 		margin-bottom: 6rem;
 		margin-top: 6rem;
 	}
@@ -5699,8 +5699,8 @@ a.to-the-top > * {
 		max-width: calc((100% - 58rem) / 2 - 4rem);
 	}
 
-	.entry-content > .alignwide:not(.wp-block-group),
-	.entry-content > .alignfull:not(.wp-block-group) {
+	.entry-content > .alignwide:not(.wp-block-group.has-background),
+	.entry-content > .alignfull:not(.wp-block-group.has-background) {
 		margin-bottom: 8rem;
 		margin-top: 8rem;
 	}

--- a/style.css
+++ b/style.css
@@ -5177,8 +5177,8 @@ a.to-the-top > * {
 		margin: 0.3rem 0 2rem 2rem;
 	}
 
-	.entry-content > .alignwide:not(.wp-block-group),
-	.entry-content > .alignfull:not(.wp-block-group) {
+	.entry-content > .alignwide:not(.wp-block-group.has-background),
+	.entry-content > .alignfull:not(.wp-block-group.has-background) {
 		margin-bottom: 6rem;
 		margin-top: 6rem;
 	}
@@ -5737,8 +5737,8 @@ a.to-the-top > * {
 		max-width: calc((100% - 58rem) / 2 - 4rem);
 	}
 
-	.entry-content > .alignwide:not(.wp-block-group),
-	.entry-content > .alignfull:not(.wp-block-group) {
+	.entry-content > .alignwide:not(.wp-block-group.has-background),
+	.entry-content > .alignfull:not(.wp-block-group.has-background) {
 		margin-bottom: 8rem;
 		margin-top: 8rem;
 	}


### PR DESCRIPTION
Adds a missing exclusionary condition to allow wide align blocks to keep vertical margins when they **do not** have a background color.

See: #997