### PR TITLE
Remove .section-inner.thin from the cover template

### DIFF
--- a/template-parts/content-cover.php
+++ b/template-parts/content-cover.php
@@ -123,7 +123,7 @@
 		</div><!-- .cover-header-inner-wrapper -->
 	</div><!-- .cover-header -->
 
-	<div class="post-inner section-inner thin" id="post-inner">
+	<div class="post-inner" id="post-inner">
 
 		<div class="entry-content">
 


### PR DESCRIPTION
Removes the `.section-inner.thin` classes from the `.post-inner` element on the cover template, matching the structure used on `content.php` and fixing the alignment issue seen on http://2020.wordpress.net/about/.