### PR TITLE
Remove the 0 left-margin on some recent post blocks, uses auto instead

### DIFF
--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3346,12 +3346,6 @@ figure.wp-block-table.is-style-stripes {
 
 /* Block: Widget Latest Posts ---------------- */
 
-.wp-block-latest-posts.is-grid,
-.wp-block-latest-posts.has-dates,
-.wp-block-latest-posts.has-dates li {
-	margin-right: 0;
-}
-
 .wp-block-latest-posts.is-grid li {
 	border-top: 0.2rem solid #dcd7ca;
 	margin-top: 2rem;

--- a/style.css
+++ b/style.css
@@ -3364,12 +3364,6 @@ figure.wp-block-table.is-style-stripes {
 
 /* Block: Widget Latest Posts ---------------- */
 
-.wp-block-latest-posts.is-grid,
-.wp-block-latest-posts.has-dates,
-.wp-block-latest-posts.has-dates li {
-	margin-left: 0;
-}
-
 .wp-block-latest-posts.is-grid li {
 	border-top: 0.2rem solid #dcd7ca;
 	margin-top: 2rem;


### PR DESCRIPTION
fixes item from doc: _The latest posts widget block isn’t aligned correctly_